### PR TITLE
Instantiate admin menu conditionally

### DIFF
--- a/Plugin_UFSC_GESTION_CLUB_13072025.php
+++ b/Plugin_UFSC_GESTION_CLUB_13072025.php
@@ -182,8 +182,10 @@ if (file_exists(UFSC_PLUGIN_PATH . 'includes/shortcodes-front.php')) {
         require_once UFSC_PLUGIN_PATH . 'includes/frontend/ajax/licenses-direct.php';
     }
 
-    UFSC_Menu();
-    UFSC_Document_Manager::get_instance();
+    if (is_admin()) {
+        new UFSC_Menu();
+        UFSC_Document_Manager::get_instance();
+    }
 
     /**
      * Load text domain for translations


### PR DESCRIPTION
## Summary
- Instantiate UFSC_Menu class only when running in admin context
- Initialize Document Manager alongside menu within the same admin check

## Testing
- `php -l Plugin_UFSC_GESTION_CLUB_13072025.php`
- `phpunit tests/phpunit/test-ufsc-wc-handler.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adae9259e4832b90a5345c10f954e9