### PR TITLE
Fix draft button submission in licence form

### DIFF
--- a/assets/js/ufsc-front.js
+++ b/assets/js/ufsc-front.js
@@ -58,6 +58,13 @@
 
   // Intercept form submit to add to cart via AJAX
   $(document).on('submit', '#ufsc-licence-form, form#ufsc-licence-form, form.ufsc-licence-form', function(e){
+    var submitter = e.originalEvent && e.originalEvent.submitter;
+    if(submitter && (submitter.id === 'ufsc-save-draft' || $(submitter).hasClass('ufsc-btn-save-draft') || submitter.name === 'ufsc_save_draft')){
+      return;
+    }
+    if($(this).find('input[name="ufsc_save_draft"]').length){
+      return;
+    }
     e.preventDefault();
     var $form = $(this);
     var $btn = $form.find('button[type=\"submit\"], .ufsc-btn-add-to-cart').first();

--- a/includes/frontend/parts/licence-form.php
+++ b/includes/frontend/parts/licence-form.php
@@ -523,7 +523,7 @@ $quota_percentage = $quota_total > 0 ? min(100, ($licences_count / $quota_total)
                     </div>
                     
                     <div class="ufsc-form-actions-secondary">
-                        <button type="submit" name="ufsc_save_draft" class="ufsc-btn ufsc-btn-outline ufsc-btn-medium">
+                        <button type="button" id="ufsc-save-draft" name="ufsc_save_draft" class="ufsc-btn ufsc-btn-outline ufsc-btn-medium ufsc-btn-save-draft">
                             <i class="dashicons dashicons-edit"></i>
                             Mettre en brouillon
                         </button>


### PR DESCRIPTION
## Summary
- prevent "Mettre en brouillon" button from submitting licence form by converting to regular button with identifier
- bind draft save script to new button and skip form submit interception when saving draft

## Testing
- `php -l includes/frontend/parts/licence-form.php`
- `node --check assets/js/ufsc-front.js`
- `npm install jquery jsdom` *(fails: 403 Forbidden)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68adb555d8b8832b8fb4784882f91eb5