### PR TITLE
Allow licence table columns to wrap and scroll

### DIFF
--- a/assets/css/admin-licences.css
+++ b/assets/css/admin-licences.css
@@ -8,6 +8,11 @@
  * @since 1.3.0
  */
 
+/* Wrapper to enable horizontal scroll when table overflows */
+.ufsc-licences-table-wrapper {
+    overflow-x: auto;
+}
+
 /* Main table layout */
 .ufsc-licences-table {
     table-layout: auto;
@@ -19,7 +24,7 @@
 .ufsc-licences-table th,
 .ufsc-licences-table td {
     vertical-align: middle;
-    white-space: nowrap;
+    white-space: normal;
 }
 
 /* Actions column specific styling */

--- a/assets/js/datatables-config.js
+++ b/assets/js/datatables-config.js
@@ -52,29 +52,29 @@ jQuery(document).ready(function($) {
                 const exportColumns = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]; // Exclut checkbox (0) et Actions (14)
                 const columnDefs = [
                     // Colonne de sélection (checkbox)
-                    { targets: 0, orderable: false, searchable: false, width: '40px' },
+                    { targets: 0, orderable: false, searchable: false },
                     // ID
-                    { targets: 1, width: '50px' },
+                    { targets: 1 },
                     // Nom et prénom
-                    { targets: [2, 3], width: '120px' },
+                    { targets: [2, 3] },
                     // Sexe
-                    { targets: 4, width: '80px' },
+                    { targets: 4 },
                     // Date de naissance
-                    { targets: 5, width: '100px' },
+                    { targets: 5 },
                     // Email
-                    { targets: 6, width: '180px' },
+                    { targets: 6 },
                     // Ville et région
-                    { targets: [7, 8], width: '120px' },
+                    { targets: [7, 8] },
                     // Club
-                    { targets: 9, width: '150px' },
+                    { targets: 9 },
                     // Statut (nouvelle colonne)
-                    { targets: 10, width: '100px' },
+                    { targets: 10 },
                     // Compétition et Inclus
-                    { targets: [11, 12], width: '90px' },
+                    { targets: [11, 12] },
                     // Date d'inscription
-                    { targets: 13, width: '100px' },
+                    { targets: 13 },
                     // Actions
-                    { targets: 14, orderable: false, searchable: false, width: '200px' }
+                    { targets: 14, orderable: false, searchable: false }
                 ];
                 
                 initializeDataTable(tableId, exportColumns, columnDefs, true, 'Club');
@@ -109,25 +109,25 @@ jQuery(document).ready(function($) {
                 const exportColumns = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]; // Exclut seulement Actions (12)
                 const columnDefs = [
                     // ID
-                    { targets: 0, width: '50px' },
+                    { targets: 0 },
                     // Nom et prénom
-                    { targets: [1, 2], width: '120px' },
+                    { targets: [1, 2] },
                     // Sexe
-                    { targets: 3, width: '80px' },
+                    { targets: 3 },
                     // Date de naissance
-                    { targets: 4, width: '100px' },
+                    { targets: 4 },
                     // Email
-                    { targets: 5, width: '180px' },
+                    { targets: 5 },
                     // Ville et région
-                    { targets: [6, 7], width: '120px' },
+                    { targets: [6, 7] },
                     // Club
-                    { targets: 8, width: '150px' },
+                    { targets: 8 },
                     // Compétition et Inclus
-                    { targets: [9, 10], width: '90px' },
+                    { targets: [9, 10] },
                     // Date d'inscription
-                    { targets: 11, width: '100px' },
+                    { targets: 11 },
                     // Actions
-                    { targets: 12, orderable: false, searchable: false, width: '180px' }
+                    { targets: 12, orderable: false, searchable: false }
                 ];
                 
                 initializeDataTable(tableId, exportColumns, columnDefs, false, 'Global');

--- a/includes/licences/admin-licence-list.php
+++ b/includes/licences/admin-licence-list.php
@@ -209,34 +209,35 @@ $export_nonce = wp_create_nonce('ufsc_export_licences_' . $club_id);
     </div>
 
     <!-- 📋 Tableau des licences avec DataTables -->
-    <table id="licenses-table-club" class="widefat fixed striped display nowrap ufsc-licences-table" style="width:100%">
-        <thead>
-        <tr>
-            <th style="width: 40px;"><input type="checkbox" id="ufsc-select-all" title="Sélectionner tout"></th>
-            <th>ID</th><th>Nom</th><th>Prénom</th><th>Sexe</th><th>Naissance</th>
-            <th>Email</th><th>Ville</th><th>Région</th><th>Club</th><th>Statut</th><th>Compétition</th><th>Inclus</th><th>Inscrit</th><th>Attestation</th><th>Actions</th>
-        </tr>
-        </thead>
-        <tbody>
-        <?php if ($data): foreach ($data as $lic): ?>
+    <div class="ufsc-licences-table-wrapper">
+        <table id="licenses-table-club" class="widefat fixed striped display nowrap ufsc-licences-table" style="width:100%">
+            <thead>
             <tr>
-                <td><input type="checkbox" name="licence_ids[]" value="<?php echo esc_attr($lic->id); ?>" class="ufsc-licence-checkbox"></td>
-                <td><?php echo esc_html($lic->id); ?></td>
-                <td><?php echo esc_html($lic->nom); ?></td>
-                <td><?php echo esc_html($lic->prenom); ?></td>
-                <td>
-                    <span class="ufsc-badge <?php echo $lic->sexe === 'F' ? 'badge-pink' : 'badge-blue'; ?>">
-                        <?php echo $lic->sexe === 'F' ? 'Femme' : 'Homme'; ?>
-                    </span>
-                </td>
-                <td><?php echo esc_html($lic->date_naissance); ?></td>
-                <td><?php echo esc_html($lic->email); ?></td>
-                <td><?php echo esc_html($lic->ville); ?></td>
-                <td><?php echo esc_html($lic->region); ?></td>
-                <td><strong><?php echo esc_html($lic->club_nom); ?></strong></td>
-                <td>
-                    <?php 
-                    $statut = $lic->statut ?? 'en_attente';
+                <th style="width: 40px;"><input type="checkbox" id="ufsc-select-all" title="Sélectionner tout"></th>
+                <th>ID</th><th>Nom</th><th>Prénom</th><th>Sexe</th><th>Naissance</th>
+                <th>Email</th><th>Ville</th><th>Région</th><th>Club</th><th>Statut</th><th>Compétition</th><th>Inclus</th><th>Inscrit</th><th>Attestation</th><th>Actions</th>
+            </tr>
+            </thead>
+            <tbody>
+            <?php if ($data): foreach ($data as $lic): ?>
+                <tr>
+                    <td><input type="checkbox" name="licence_ids[]" value="<?php echo esc_attr($lic->id); ?>" class="ufsc-licence-checkbox"></td>
+                    <td><?php echo esc_html($lic->id); ?></td>
+                    <td><?php echo esc_html($lic->nom); ?></td>
+                    <td><?php echo esc_html($lic->prenom); ?></td>
+                    <td>
+                        <span class="ufsc-badge <?php echo $lic->sexe === 'F' ? 'badge-pink' : 'badge-blue'; ?>">
+                            <?php echo $lic->sexe === 'F' ? 'Femme' : 'Homme'; ?>
+                        </span>
+                    </td>
+                    <td><?php echo esc_html($lic->date_naissance); ?></td>
+                    <td><?php echo esc_html($lic->email); ?></td>
+                    <td><?php echo esc_html($lic->ville); ?></td>
+                    <td><?php echo esc_html($lic->region); ?></td>
+                    <td><strong><?php echo esc_html($lic->club_nom); ?></strong></td>
+                    <td>
+                        <?php
+                        $statut = $lic->statut ?? 'en_attente';
                     $statut_labels = [
                         'en_attente' => 'En attente',
                         'validee' => 'Validée',
@@ -371,7 +372,8 @@ $export_nonce = wp_create_nonce('ufsc_export_licences_' . $club_id);
             <tr><td colspan="15">Aucune licence trouvée avec les critères sélectionnés.</td></tr>
         <?php endif; ?>
         </tbody>
-    </table>
+        </table>
+    </div>
 
 </div>
 


### PR DESCRIPTION
## Summary
- Allow licence table cells to wrap by default and provide horizontal scroll via `.ufsc-licences-table-wrapper`.
- Remove fixed column widths in DataTables config so columns size automatically.
- Wrap club licence table in a scrollable div to prevent viewport overflow.

## Testing
- `php -l includes/licences/admin-licence-list.php`
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adb925dda0832b9d9cbefc192321d7