### PR TITLE
Guard licence queries against missing club IDs

### DIFF
--- a/includes/clubs/class-club-manager.php
+++ b/includes/clubs/class-club-manager.php
@@ -512,11 +512,14 @@ class UFSC_Club_Manager
      */
     public function get_licences_by_club($club_id)
     {
+        if (empty($club_id)) {
+            return [];
+        }
         // Use License Manager for proper license operations
         if (!class_exists('UFSC_Licence_Manager')) {
             require_once UFSC_PLUGIN_PATH . 'includes/licences/class-licence-manager.php';
         }
-        
+
         $licence_manager = new UFSC_Licence_Manager();
         return $licence_manager->get_licences(['club_id' => $club_id]);
     }

--- a/includes/licences/class-licence-manager.php
+++ b/includes/licences/class-licence-manager.php
@@ -296,13 +296,15 @@ class UFSC_Licence_Manager
      */
     public function get_licences($filters = [])
     {
+        if (!isset($filters['club_id']) || intval($filters['club_id']) <= 0) {
+            return [];
+        }
+
         $where = ['1=1'];
         $params = [];
 
-        if (!empty($filters['club_id'])) {
-            $where[] = 'l.club_id = %d';
-            $params[] = intval($filters['club_id']);
-        }
+        $where[] = 'l.club_id = %d';
+        $params[] = intval($filters['club_id']);
 
         if (!empty($filters['search'])) {
             $where[] = '(l.nom LIKE %s OR l.prenom LIKE %s OR l.email LIKE %s)';


### PR DESCRIPTION
## Summary
- Avoid retrieving licences when club ID is empty by short-circuiting `UFSC_Club_Manager::get_licences_by_club`
- Ensure `UFSC_Licence_Manager::get_licences` returns an empty result when `club_id` is missing or zero

## Testing
- `php -l includes/clubs/class-club-manager.php`
- `php -l includes/licences/class-licence-manager.php`
- `php /tmp/test.php`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adc5b544b8832bbbf56fffce62a605