### PR TITLE
Use affiliation page for club creation fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Le plugin utilise des pages WordPress dédiées pour l'interface frontend. Ces p
 
 Les pages sont créées automatiquement avec des permaliens optimisés. Vous pouvez les personnaliser dans `Pages > Toutes les pages`.
 
+> ℹ️ Si aucune page "Formulaire Club" n'est configurée, le bouton "Créer un club" du tableau de bord redirige automatiquement vers la page d'affiliation.
+
 ### Shortcodes disponibles
 
 #### Navigation et interface (v1.3.0)

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -289,6 +289,11 @@ function ufsc_get_safe_page_url($page_type, $fallback_text = 'Page non configur√
     }
     
     $page_id = get_option($option_map[$page_type], 0);
+
+    // Fallback: if club_form is not configured, use affiliation page
+    if ($page_type === 'club_form' && (int) $page_id === 0) {
+        $page_id = get_option('ufsc_affiliation_page_id', 0);
+    }
     
     if ($page_id && get_post_status($page_id) === 'publish') {
         return [

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -36,10 +36,10 @@ function ufsc_get_no_club_message($context = 'general') {
                     <p>Vous n\'êtes pas associé à un club affilié.</p>
                     </div>';
         case 'dashboard':
-            $club_form_button = ufsc_generate_safe_navigation_button('club_form', 'Créer un club', 'ufsc-btn', true);
+            $affiliation_button = ufsc_generate_safe_navigation_button('affiliation', 'Créer un club', 'ufsc-btn', true);
             return '<div class="ufsc-alert ufsc-alert-error">
                     <p>Vous n\'êtes pas associé à un club. Veuillez contacter l\'administrateur ou créer un club.</p>
-                    <p>' . $club_form_button . '</p>
+                    <p>' . $affiliation_button . '</p>
                     </div>';
         default:
             return '<div class="ufsc-alert ufsc-alert-error">

--- a/includes/tests/frontend-fixes-test.php
+++ b/includes/tests/frontend-fixes-test.php
@@ -25,7 +25,7 @@ function ufsc_test_frontend_fixes()
     echo "<h2>🧪 Test - Correctifs Frontend UFSC</h2>";
     
     $tests_passed = 0;
-    $total_tests = 6;
+    $total_tests = 7;
     $errors = [];
     
     try {
@@ -151,7 +151,47 @@ function ufsc_test_frontend_fixes()
             echo "<p>$error</p>";
             $errors[] = $error;
         }
-        
+
+        // Test 7: Fallback vers la page d'affiliation pour la création de club
+        echo "<h3>Test 7: Fallback de la page club vers l'affiliation</h3>";
+
+        if (function_exists('ufsc_get_safe_page_url')) {
+            global $mock_options;
+            $mock_options = [
+                'ufsc_club_form_page_id' => 0,
+                'ufsc_affiliation_page_id' => 123,
+            ];
+
+            if (!function_exists('get_option')) {
+                function get_option($name, $default = false) {
+                    global $mock_options;
+                    return $mock_options[$name] ?? $default;
+                }
+            }
+
+            if (!function_exists('get_post_status')) {
+                function get_post_status($id) {
+                    return $id ? 'publish' : false;
+                }
+            }
+
+            if (!function_exists('get_permalink')) {
+                function get_permalink($id) {
+                    return 'page-' . $id;
+                }
+            }
+
+            $fallback_result = ufsc_get_safe_page_url('club_form');
+            if ($fallback_result['available'] && $fallback_result['url'] === 'page-123') {
+                echo "<p>✅ La fonction retourne la page d'affiliation lorsque la page de formulaire de club n'est pas configurée.</p>";
+                $tests_passed++;
+            } else {
+                $error = "❌ La fonction n'a pas utilisé la page d'affiliation en fallback.";
+                echo "<p>$error</p>";
+                $errors[] = $error;
+            }
+        }
+
     } catch (Exception $e) {
         $errors[] = "Exception: " . $e->getMessage();
         echo "<p>❌ Exception: " . esc_html($e->getMessage()) . "</p>";


### PR DESCRIPTION
## Summary
- Point the "no club" dashboard message to the affiliation page.
- Fallback to the affiliation page when the club-form page isn’t configured.
- Document and test the new fallback behaviour.

## Testing
- `php /tmp/run-tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68adc54854d4832bb301e1624d674004