### PR TITLE
Document club form page option and shortcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the UFSC Gestion Club plugin will be documented in this f
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - 2025-08-26
+
+### Added
+- Documentation and admin setting for `ufsc_club_form_page_id` with `[ufsc_formulaire_club]` shortcode.
+
 ## [1.3.0] - 2025-01-21
 
 ### Added

--- a/DOC_FRONTEND_SHORTCODES.md
+++ b/DOC_FRONTEND_SHORTCODES.md
@@ -102,7 +102,17 @@ Formulaires et boutons de téléchargement d'attestations.
 ### [ufsc_liste_clubs]
 Liste publique des clubs affiliés.
 
-### [ufsc_affiliation_club_form] / [ufsc_formulaire_club]
+### [ufsc_formulaire_club]
+Affiche le formulaire de création ou d'édition de club. La page qui contient ce shortcode doit être définie via l'option `ufsc_club_form_page_id` dans `UFSC > Réglages`.
+
+**Exemple :**
+```
+[ufsc_formulaire_club]
+```
+
+![Réglage Page Formulaire de club](assets/docs/club-form-page-setting.svg)
+
+### [ufsc_affiliation_club_form]
 Formulaire d'affiliation club (version standalone).
 
 ## Fonctionnalités Techniques
@@ -137,6 +147,7 @@ Formulaire d'affiliation club (version standalone).
 - `ufsc_licence_product_id` : ID du produit WooCommerce pour les licences (défaut: 2934)
 - `ufsc_affiliation_product_id` : ID du produit WooCommerce pour les affiliations (défaut: 2933)
 - `ufsc_manual_validation` : Active la validation manuelle des licences (défaut: false)
+- `ufsc_club_form_page_id` : ID de la page contenant le shortcode `[ufsc_formulaire_club]`
 
 ### Pages Requises
 Pour un fonctionnement optimal, configurez ces pages dans les réglages UFSC :

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Le plugin utilise des pages WordPress dédiées pour l'interface frontend. Ces p
 |------|-----------|-----|-------------|
 | **Tableau de Bord Club** | `[ufsc_club_dashboard]` | `/tableau-de-bord-club/` | Espace privé des clubs affiliés |
 | **Affiliation Club** | `[ufsc_affiliation_form]` | `/affiliation-club/` | Formulaire d'affiliation |
+| **Formulaire de Club** | `[ufsc_formulaire_club]` | `/formulaire-club/` | Création ou modification du club |
 | **Compte Club** | `[ufsc_club_account]` | `/compte-club/` | Gestion du compte club |
 | **Gestion des Licences** | `[ufsc_club_licences]` | `/gestion-licences/` | Gestion des licences du club |
 | **Ajouter un Licencié** | `[ufsc_ajouter_licencie]` | `/ajouter-licencie/` | Ajout de licenciés |
@@ -72,6 +73,14 @@ Le plugin utilise des pages WordPress dédiées pour l'interface frontend. Ces p
 | **Liste des Clubs** | `[ufsc_liste_clubs]` | `/liste-clubs/` | Liste publique des clubs |
 
 Les pages sont créées automatiquement avec des permaliens optimisés. Vous pouvez les personnaliser dans `Pages > Toutes les pages`.
+
+### Formulaire de club
+
+L'option `ufsc_club_form_page_id` permet de définir la page WordPress qui héberge le formulaire de création ou d'édition de club. Cette page doit contenir le shortcode `[ufsc_formulaire_club]`.
+
+Configurez cette page dans l'interface d'administration : `UFSC > Réglages > Configuration des pages`.
+
+![Réglage Page Formulaire de club](assets/docs/club-form-page-setting.svg)
 
 ### Shortcodes disponibles
 

--- a/assets/docs/club-form-page-setting.svg
+++ b/assets/docs/club-form-page-setting.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="400">
+  <rect width="800" height="400" fill="#fff"/>
+  <text x="50%" y="40%" dominant-baseline="middle" text-anchor="middle" font-size="24" font-family="Arial" fill="#000">UFSC &gt; Réglages</text>
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-size="18" font-family="Arial" fill="#000">Page Formulaire de club</text>
+</svg>

--- a/includes/admin/class-menu.php
+++ b/includes/admin/class-menu.php
@@ -2262,6 +2262,10 @@ class UFSC_Menu
             'sanitize_callback' => 'absint',
             'default' => 0
         ));
+        register_setting('ufsc_settings', 'ufsc_club_form_page_id', array(
+            'sanitize_callback' => 'absint',
+            'default' => 0
+        ));
         register_setting('ufsc_settings', 'ufsc_licence_page_id', array(
             'sanitize_callback' => 'absint',
             'default' => 0
@@ -2336,6 +2340,15 @@ class UFSC_Menu
             'affiliation_page',
             __('Page Affiliation', 'plugin-ufsc-gestion-club-13072025'),
             array($this, 'affiliation_page_callback'),
+            'ufsc-settings',
+            'ufsc_page_config_section'
+        );
+
+        // Club form page setting
+        add_settings_field(
+            'club_form_page',
+            __('Page Formulaire de club', 'plugin-ufsc-gestion-club-13072025'),
+            array($this, 'club_form_page_callback'),
             'ufsc-settings',
             'ufsc_page_config_section'
         );
@@ -4122,6 +4135,26 @@ class UFSC_Menu
             <?php endforeach; ?>
         </select>
         <p class="description"><?php esc_html_e('Page contenant le formulaire d\'affiliation des clubs.', 'plugin-ufsc-gestion-club-13072025'); ?></p>
+        <?php
+    }
+
+    /**
+     * Club form page field callback
+     */
+    public function club_form_page_callback()
+    {
+        $page_id = get_option('ufsc_club_form_page_id', 0);
+        $pages = $this->get_pages_for_dropdown();
+        ?>
+        <select id="ufsc_club_form_page_id" name="ufsc_club_form_page_id">
+            <option value="0"><?php esc_html_e('-- Sélectionner une page --', 'plugin-ufsc-gestion-club-13072025'); ?></option>
+            <?php foreach ($pages as $page): ?>
+                <option value="<?php echo esc_attr($page->ID); ?>" <?php selected($page_id, $page->ID); ?>>
+                    <?php echo esc_html($page->post_title); ?>
+                </option>
+            <?php endforeach; ?>
+        </select>
+        <p class="description"><?php esc_html_e('Page contenant le formulaire de création ou d\'édition de club.', 'plugin-ufsc-gestion-club-13072025'); ?></p>
         <?php
     }
 


### PR DESCRIPTION
## Summary
- document `ufsc_club_form_page_id` option and `[ufsc_formulaire_club]` shortcode in README and shortcode guide with example screenshot
- add admin setting for the club form page alongside existing page selectors
- record documentation update in changelog

## Testing
- `php -l includes/admin/class-menu.php`
- `phpunit tests/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adc551c1f4832bb624c42cfad0adf3