### PR TITLE
Fix format arrays for licence draft database operations

### DIFF
--- a/includes/frontend/ajax/licence-drafts.php
+++ b/includes/frontend/ajax/licence-drafts.php
@@ -42,17 +42,17 @@ function ufsc_ajax_save_draft(){
         $updated = $wpdb->update(
             $table,
             array(
-                'nom'            => $nom,
-                'prenom'         => $prenom,
-                'email'          => $email,
-                'statut'         => 'brouillon',
-                'date_creation'  => $now,
+                'nom'           => $nom,
+                'prenom'        => $prenom,
+                'email'         => $email,
+                'statut'        => 'brouillon',
+                'date_creation' => $now,
             ),
             array(
                 'id'      => $licence_id,
                 'club_id' => $club_id,
             ),
-            array('%s','%s','%s','%s','%s','%s'),
+            array('%s','%s','%s','%s','%s'),
             array('%d','%d')
         );
         if ( $updated !== false ) {
@@ -62,15 +62,18 @@ function ufsc_ajax_save_draft(){
         }
     } else {
         // Create draft
-        $inserted = $wpdb->insert($table, array('club_id'=>$club_id,
-                'role' => $role,
-                'nom'            => $nom,
-                'prenom'         => $prenom,
-                'email'          => $email,
-                'statut'         => 'brouillon',
-                'date_creation'  => $now,
+        $inserted = $wpdb->insert(
+            $table,
+            array(
+                'club_id'       => $club_id,
+                'role'          => $role,
+                'nom'           => $nom,
+                'prenom'        => $prenom,
+                'email'         => $email,
+                'statut'        => 'brouillon',
+                'date_creation' => $now,
             ),
-            array('%d','%s','%s','%s','%s','%s')
+            array('%d','%s','%s','%s','%s','%s','%s')
         );
         if ( $inserted ) {
             $new_id = (int) $wpdb->insert_id;


### PR DESCRIPTION
## Summary
- align `$wpdb->update` format placeholders with provided fields in licence draft updates
- ensure `$wpdb->insert` uses matching formats for all columns in licence draft creation

## Testing
- `php -l includes/frontend/ajax/licence-drafts.php`
- `phpunit` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68adea6bf3ec832b9822eb587a7cf83f