### PR TITLE
Centralize login prompts across shortcodes

### DIFF
--- a/includes/frontend/club/dashboard.php
+++ b/includes/frontend/club/dashboard.php
@@ -269,10 +269,7 @@ class UFSC_Club_Dashboard
         // Add action buttons based on error type
         switch ($error->get_error_code()) {
             case 'not_logged_in':
-                $output .= '<p>';
-                $output .= '<a href="' . esc_url($error_data['login_url']) . '" class="ufsc-btn">Se connecter</a> ou ';
-                $output .= '<a href="' . esc_url(wp_registration_url()) . '" class="ufsc-btn ufsc-btn-outline">Créer un compte</a>';
-                $output .= '</p>';
+                $output .= ufsc_render_login_prompt($error_data['login_url']);
                 break;
                 
             case 'no_club_associated':

--- a/includes/frontend/forms/affiliation-form-render.php
+++ b/includes/frontend/forms/affiliation-form-render.php
@@ -35,14 +35,9 @@ function ufsc_render_affiliation_form($args = [])
     
     // Check if user is logged in
     if (!is_user_logged_in()) {
-        return '<div class="ufsc-alert ufsc-alert-error">
-            <h4>Connexion requise</h4>
-            <p>Vous devez être connecté pour procéder à une affiliation.</p>
-            <p><a href="' . wp_login_url(get_permalink()) . '" class="ufsc-btn">Se connecter</a></p>
-            </div>';
+        return '<div class="ufsc-alert ufsc-alert-error">\n            <h4>Connexion requise</h4>\n            <p>Vous devez être connecté pour procéder à une affiliation.</p>' .
+            ufsc_render_login_prompt() . '\n            </div>';
     }
-    
-    $user_id = get_current_user_id();
     
     // Check if user already has a club
     $existing_club = ufsc_get_user_club($user_id);

--- a/includes/frontend/shortcodes/affiliation-form-shortcode.php
+++ b/includes/frontend/shortcodes/affiliation-form-shortcode.php
@@ -16,10 +16,9 @@ function ufsc_formulaire_affiliation_shortcode($atts)
     // Si l'utilisateur n'est pas connecté, afficher formulaire de connexion
     if (!is_user_logged_in()) {
         return '<div class="ufsc-alert ufsc-alert-error">
-                <p>Vous devez être connecté pour accéder au formulaire d\'affiliation.</p>
-                <p><a href="' . wp_login_url(get_permalink()) . '" class="ufsc-btn">Se connecter</a> ou 
-                <a href="' . wp_registration_url() . '" class="ufsc-btn ufsc-btn-outline">Créer un compte</a></p>
-                </div>';
+                <p>Vous devez être connecté pour accéder au formulaire d\'affiliation.</p>' .
+                ufsc_render_login_prompt() .
+                '</div>';
     }
 
     // Vérifier si l'utilisateur a déjà un club affilié

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -522,8 +522,26 @@ function ufsc_render_club_status_alert($club, $context = 'general')
 }
 
 /**
+ * Render standardized login/register prompt.
+ *
+ * @param string $login_url    Optional custom login URL.
+ * @param string $register_url Optional custom registration URL.
+ * @return string HTML block containing login and registration buttons.
+ */
+function ufsc_render_login_prompt($login_url = '', $register_url = '')
+{
+    $login_url = $login_url ?: wp_login_url(get_permalink());
+    $register_url = $register_url ?: wp_registration_url();
+
+    return '<p><a href="' . esc_url($login_url) . '" class="ufsc-btn">' .
+        esc_html__('Se connecter', 'plugin-ufsc-gestion-club-13072025') . '</a> ' .
+        '<a href="' . esc_url($register_url) . '" class="ufsc-btn ufsc-btn-outline">' .
+        esc_html__('Créer un compte', 'plugin-ufsc-gestion-club-13072025') . '</a></p>';
+}
+
+/**
  * CORRECTION: Comprehensive frontend access control check
- * 
+ *
  * This function centralizes all frontend access control logic including:
  * - User authentication verification
  * - Club association validation 
@@ -540,11 +558,11 @@ function ufsc_check_frontend_access($context = 'general')
     if (!is_user_logged_in()) {
         return [
             'allowed' => false,
-            'error_message' => '<div class="ufsc-alert ufsc-alert-error">
-                <h4>Connexion requise</h4>
-                <p>Vous devez être connecté pour accéder à cette page.</p>
-                <p><a href="' . wp_login_url(get_permalink()) . '" class="ufsc-btn">Se connecter</a></p>
-                </div>',
+            'error_message' => '<div class="ufsc-alert ufsc-alert-error">'
+                . '<h4>Connexion requise</h4>'
+                . '<p>Vous devez être connecté pour accéder à cette page.</p>'
+                . ufsc_render_login_prompt()
+                . '</div>',
             'club' => null
         ];
     }

--- a/includes/shortcodes-attestations.php
+++ b/includes/shortcodes-attestations.php
@@ -69,9 +69,9 @@ function ufsc_attestation_upload_club_shortcode($atts) {
     // Check if user is logged in
     if (!is_user_logged_in()) {
         return '<div class="ufsc-alert ufsc-alert-error">
-                <p>Vous devez être connecté pour télécharger une attestation.</p>
-                <p><a href="' . wp_login_url(get_permalink()) . '" class="ufsc-btn">Se connecter</a></p>
-                </div>';
+                <p>Vous devez être connecté pour télécharger une attestation.</p>' .
+                ufsc_render_login_prompt() .
+                '</div>';
     }
     
     $atts = shortcode_atts([
@@ -121,9 +121,9 @@ function ufsc_attestation_upload_license_shortcode($atts) {
     // Check if user is logged in
     if (!is_user_logged_in()) {
         return '<div class="ufsc-alert ufsc-alert-error">
-                <p>Vous devez être connecté pour télécharger une attestation.</p>
-                <p><a href="' . wp_login_url(get_permalink()) . '" class="ufsc-btn">Se connecter</a></p>
-                </div>';
+                <p>Vous devez être connecté pour télécharger une attestation.</p>' .
+                ufsc_render_login_prompt() .
+                '</div>';
     }
     
     $atts = shortcode_atts([
@@ -173,9 +173,9 @@ function ufsc_attestation_list_shortcode($atts) {
     // Check if user is logged in
     if (!is_user_logged_in()) {
         return '<div class="ufsc-alert ufsc-alert-error">
-                <p>Vous devez être connecté pour voir vos attestations.</p>
-                <p><a href="' . wp_login_url(get_permalink()) . '" class="ufsc-btn">Se connecter</a></p>
-                </div>';
+                <p>Vous devez être connecté pour voir vos attestations.</p>' .
+                ufsc_render_login_prompt() .
+                '</div>';
     }
     
     $atts = shortcode_atts([

--- a/includes/shortcodes-front.php
+++ b/includes/shortcodes-front.php
@@ -195,9 +195,6 @@ function ufsc_club_dashboard_content($atts = array()) {
  * @return string HTML output
  */
 function ufsc_render_login_requirement($context = '') {
-    $login_url = wp_login_url(get_permalink());
-    $register_url = wp_registration_url();
-
     $nonce = wp_create_nonce('ufsc_frontend_action');
 
     $extra_message = '';
@@ -205,21 +202,15 @@ function ufsc_render_login_requirement($context = '') {
         $extra_message = '<p>' . esc_html__('Veuillez vous connecter pour créer votre club.', 'plugin-ufsc-gestion-club-13072025') . '</p>';
     }
 
-    return '<div class="ufsc-login-required">
-        <div class="ufsc-alert ufsc-alert-info">
-            <h4>' . esc_html__('Connexion requise', 'plugin-ufsc-gestion-club-13072025') . '</h4>
-            <p>' . esc_html__('Vous devez être connecté pour accéder à cette section.', 'plugin-ufsc-gestion-club-13072025') . '</p>' .
-            $extra_message . '
-            <div class="ufsc-button-group">
-                <a href="' . esc_url($login_url) . '" class="ufsc-btn ufsc-btn-primary">' .
-                    esc_html__('Se connecter', 'plugin-ufsc-gestion-club-13072025') . '</a>
-                ' . (get_option('users_can_register') ?
-                    '<a href="' . esc_url($register_url) . '" class="ufsc-btn ufsc-btn-outline">' .
-                        esc_html__('Créer un compte', 'plugin-ufsc-gestion-club-13072025') . '</a>' : '') . '
-            </div>
-        </div>
-        <input type="hidden" name="ufsc_nonce" value="' . esc_attr($nonce) . '">
-    </div>';
+    return '<div class="ufsc-login-required">'
+        . '<div class="ufsc-alert ufsc-alert-info">'
+            . '<h4>' . esc_html__('Connexion requise', 'plugin-ufsc-gestion-club-13072025') . '</h4>'
+            . '<p>' . esc_html__('Vous devez être connecté pour accéder à cette section.', 'plugin-ufsc-gestion-club-13072025') . '</p>'
+            . $extra_message
+            . ufsc_render_login_prompt()
+        . '</div>'
+        . '<input type="hidden" name="ufsc_nonce" value="' . esc_attr($nonce) . '">'
+        . '</div>';
 }
 
 /**

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -135,10 +135,9 @@ function ufsc_render_affiliation_club_form($atts = [])
     // Si l'utilisateur n'est pas connecté, afficher formulaire de connexion
     if (!is_user_logged_in()) {
         return '<div class="ufsc-alert ufsc-alert-error">
-                <p>Vous devez être connecté pour accéder au formulaire d\'affiliation.</p>
-                <p><a href="' . wp_login_url(get_permalink()) . '" class="ufsc-btn">Se connecter</a> ou 
-                <a href="' . wp_registration_url() . '" class="ufsc-btn ufsc-btn-outline">Créer un compte</a></p>
-                </div>';
+                <p>Vous devez être connecté pour accéder au formulaire d\'affiliation.</p>' .
+                ufsc_render_login_prompt() .
+                '</div>';
     }
 
     // Vérifier si l'utilisateur a déjà un club affilié


### PR DESCRIPTION
## Summary
- add `ufsc_render_login_prompt()` helper to produce standardized login/register buttons
- refactor frontend shortcodes and dashboard errors to use the new helper
- streamline access control checks through centralized prompt rendering

## Testing
- `php -l includes/helpers.php`
- `php -l includes/shortcodes.php`
- `php -l includes/frontend/shortcodes/affiliation-form-shortcode.php`
- `php -l includes/shortcodes-attestations.php`
- `php -l includes/frontend/forms/affiliation-form-render.php`
- `php -l includes/frontend/club/dashboard.php`
- `php -l includes/shortcodes-front.php`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aded33ac2c832bb76a5d1fed657ca0