### PR TITLE
Add login/registration buttons for club form shortcode

### DIFF
--- a/includes/frontend/shortcodes/club-form-shortcode.php
+++ b/includes/frontend/shortcodes/club-form-shortcode.php
@@ -13,9 +13,15 @@ if (!defined('ABSPATH')) {
  */
 function ufsc_formulaire_club_shortcode($atts)
 {
-    // Si l'utilisateur n'est pas connecté, afficher un message d'erreur
+    // Si l'utilisateur n'est pas connecté, afficher le bloc de connexion/inscription
     if (!is_user_logged_in()) {
-        return '<p class="ufsc-error">Vous devez être connecté pour accéder à ce formulaire.</p>';
+        $register_page_id = get_option('ufsc_login_page_id', 0);
+        $register_url = $register_page_id ? get_permalink($register_page_id) : wp_registration_url();
+        return '<div class="ufsc-alert ufsc-alert-error">'
+            . '<p>Vous devez être connecté pour accéder à ce formulaire.</p>'
+            . '<p><a href="' . wp_login_url(get_permalink()) . '" class="ufsc-btn">Se connecter</a> ou '
+            . '<a href="' . $register_url . '" class="ufsc-btn ufsc-btn-outline">Créer un compte</a></p>'
+            . '</div>';
     }
 
     // Démarrer la capture de sortie


### PR DESCRIPTION
## Summary
- Show styled login and registration buttons when accessing club form shortcode while not logged in
- Use plugin login page for registration link when available

## Testing
- `php -l includes/frontend/shortcodes/club-form-shortcode.php`
- `php -r 'define("ABSPATH","/"); function is_user_logged_in(){return false;} function wp_login_url($url=""){return "login?redirect_to=".$url;} function get_permalink(){return "http://example.com/club";} function wp_registration_url(){return "http://example.com/register";} function get_option($key,$default=0){return 0;} function add_shortcode($tag,$func){return true;} include "includes/frontend/shortcodes/club-form-shortcode.php"; echo ufsc_formulaire_club_shortcode([]);'`
- ⚠️ `phpunit` *(command not found)*
- ⚠️ `apt-get update` *(403 on Ubuntu repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68aded2c1fa4832bbc36c5dc070f27e4