### PR TITLE
Display login/register form for unauthenticated club shortcode

### DIFF
--- a/includes/frontend/shortcodes/club-form-shortcode.php
+++ b/includes/frontend/shortcodes/club-form-shortcode.php
@@ -13,15 +13,12 @@ if (!defined('ABSPATH')) {
  */
 function ufsc_formulaire_club_shortcode($atts)
 {
-    // Si l'utilisateur n'est pas connecté, afficher le bloc de connexion/inscription
+    // Si l'utilisateur n'est pas connecté, afficher le formulaire de connexion/inscription
     if (!is_user_logged_in()) {
-        $register_page_id = get_option('ufsc_login_page_id', 0);
-        $register_url = $register_page_id ? get_permalink($register_page_id) : wp_registration_url();
-        return '<div class="ufsc-alert ufsc-alert-error">'
-            . '<p>Vous devez être connecté pour accéder à ce formulaire.</p>'
-            . '<p><a href="' . wp_login_url(get_permalink()) . '" class="ufsc-btn">Se connecter</a> ou '
-            . '<a href="' . $register_url . '" class="ufsc-btn ufsc-btn-outline">Créer un compte</a></p>'
-            . '</div>';
+        return ufsc_login_register_shortcode([
+            'redirect' => get_permalink(),
+            'show_register' => 'yes',
+        ]);
     }
 
     // Démarrer la capture de sortie

--- a/tests/phpunit/test-club-form-shortcode.php
+++ b/tests/phpunit/test-club-form-shortcode.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Tests for UFSC Club Form Shortcode visibility based on user login status.
+ *
+ * @package UFSC_Gestion_Club
+ */
+
+// Exit if accessed directly.
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Test the club form shortcode behaviour.
+ */
+class Test_UFSC_Club_Form_Shortcode extends WP_UnitTestCase
+{
+    /**
+     * Post ID used for permalink generation.
+     *
+     * @var int
+     */
+    protected $post_id;
+
+    /**
+     * Set up test environment.
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        if (!function_exists('ufsc_formulaire_club_shortcode')) {
+            $this->markTestSkipped('UFSC club form shortcode not available');
+        }
+
+        // Create a post to ensure get_permalink() returns a valid URL.
+        $this->post_id = $this->factory->post->create();
+        $GLOBALS['post'] = get_post($this->post_id);
+    }
+
+    /**
+     * Ensure no user remains logged in after tests.
+     */
+    public function tearDown(): void
+    {
+        wp_set_current_user(0);
+        parent::tearDown();
+    }
+
+    /**
+     * Test that non-logged-in users see the login/registration form.
+     */
+    public function test_non_logged_in_sees_login_register_form()
+    {
+        wp_set_current_user(0);
+        $output = ufsc_formulaire_club_shortcode([]);
+
+        $this->assertStringContainsString('ufsc-login-register-wrapper', $output);
+        $this->assertStringNotContainsString('ufsc_club_nonce', $output);
+    }
+
+    /**
+     * Test that logged-in users see the club form.
+     */
+    public function test_logged_in_sees_club_form()
+    {
+        $user_id = $this->factory->user->create();
+        wp_set_current_user($user_id);
+
+        $output = ufsc_formulaire_club_shortcode([]);
+
+        $this->assertStringContainsString('ufsc_club_nonce', $output);
+        $this->assertStringNotContainsString('ufsc-login-register-wrapper', $output);
+    }
+}
+


### PR DESCRIPTION
## Summary
- Show UFSC login/registration form when [ufsc_formulaire_club] is used by non-logged users
- Redirect back to the page after login to display club form
- Add unit tests covering login gating behavior

## Testing
- `phpunit tests/phpunit/test-club-form-shortcode.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adef925524832ba66932166ebcaefe