### PR TITLE
Log missing frontend dashboard file

### DIFF
--- a/Plugin_UFSC_GESTION_CLUB_13072025.php
+++ b/Plugin_UFSC_GESTION_CLUB_13072025.php
@@ -112,7 +112,7 @@ $file = UFSC_PLUGIN_PATH . 'includes/frontend/frontend-club-dashboard.php';
 if (file_exists($file)) {
     require_once $file;
 } else {
-    // Optionnel : noter une erreur, mais ça ne plantera plus
+    error_log('UFSC Gestion Club: missing file ' . $file);
 }
 require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/club-form-shortcode.php';
 require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/affiliation-form-shortcode.php';

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Plugin WordPress complet et professionnel permettant aux clubs UFSC (Union Fran�
    - Les tables de base de données sont créées automatiquement
    - Configurez les pages dans `UFSC > Réglages`
    - Définissez les permissions utilisateurs
+   - Un message est enregistré dans les logs PHP si le fichier `includes/frontend/frontend-club-dashboard.php` est manquant, afin de faciliter le diagnostic d'une installation incomplète
 
 ## ⚙️ Configuration
 


### PR DESCRIPTION
## Summary
- add error log when frontend dashboard file is missing
- document log requirement in installation instructions

## Testing
- `php -l Plugin_UFSC_GESTION_CLUB_13072025.php`
- `phpunit --configuration phpunit.xml` *(fails: command not found)*
- `php -r 'define("UFSC_PLUGIN_PATH", __DIR__ . "/"); $file = UFSC_PLUGIN_PATH . "includes/frontend/frontend-club-dashboard.php"; if (file_exists($file)) { require_once $file; } else { error_log("UFSC Gestion Club: missing file $file"); }'`

------
https://chatgpt.com/codex/tasks/task_e_68adf4c53048832b9693ba0eb2c1ca94