### PR TITLE
Add Composer autoload and namespaces

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,13 @@
+{
+  "name": "ufsc/gestion-club",
+  "description": "UFSC Gestion de Club plugin",
+  "type": "project",
+  "autoload": {
+    "psr-4": {
+      "UFSC\\Core\\": "includes/core/",
+      "UFSC\\Clubs\\": "includes/clubs/",
+      "UFSC\\Admin\\": "includes/admin/",
+      "UFSC\\Helpers\\": "includes/helpers/"
+    }
+  }
+}

--- a/includes/admin/AdminSettings.php
+++ b/includes/admin/AdminSettings.php
@@ -1,13 +1,6 @@
 <?php
-/**
- * UFSC Admin Settings
- *
- * Admin settings page for UFSC plugin configuration
- * Provides WooCommerce integration options and frontend behavior settings
- *
- * @package UFSC_Gestion_Club
- * @since 1.2.1
- */
+
+namespace UFSC\Admin;
 
 // Exit if accessed directly
 if (!defined('ABSPATH')) {
@@ -17,7 +10,7 @@ if (!defined('ABSPATH')) {
 /**
  * UFSC Admin Settings Class
  */
-class UFSC_Admin_Settings {
+class AdminSettings {
 
     /**
      * Settings page hook suffix
@@ -449,5 +442,5 @@ class UFSC_Admin_Settings {
 
 // Initialize the admin settings class
 if (is_admin()) {
-    new UFSC_Admin_Settings();
+    new \UFSC\Admin\AdminSettings();
 }

--- a/includes/admin/Dashboard.php
+++ b/includes/admin/Dashboard.php
@@ -1,12 +1,6 @@
 <?php
 
-/**
- * Dashboard Class
- *
- * Handles the dashboard functionality for the UFSC Gestion Club plugin
- *
- * @package UFSC_Gestion_Club
- */
+namespace UFSC\Admin;
 
 // Exit if accessed directly.
 if (!defined('ABSPATH')) {
@@ -16,7 +10,7 @@ if (!defined('ABSPATH')) {
 /**
  * Dashboard Class
  */
-class UFSC_Dashboard
+class Dashboard
 {
     /**
      * Constructor

--- a/includes/admin/DocumentManager.php
+++ b/includes/admin/DocumentManager.php
@@ -1,12 +1,9 @@
 <?php
 
-/**
- * Document Manager Class
- *
- * Handles secure document access and management for UFSC clubs
- *
- * @package UFSC_Gestion_Club
- */
+namespace UFSC\Admin;
+
+use UFSC\Clubs\ClubManager;
+use UFSC\Helpers\UploadValidator;
 
 // Exit if accessed directly.
 if (!defined('ABSPATH')) {
@@ -16,7 +13,7 @@ if (!defined('ABSPATH')) {
 /**
  * Document Manager Class
  */
-class UFSC_Document_Manager
+class DocumentManager
 {
     /**
      * Singleton instance
@@ -26,7 +23,7 @@ class UFSC_Document_Manager
     /**
      * Get singleton instance
      *
-     * @return UFSC_Document_Manager
+     * @return \UFSC\Admin\DocumentManager
      */
     public static function get_instance()
     {
@@ -130,7 +127,7 @@ class UFSC_Document_Manager
      */
     private function get_document_url($club_id, $doc_type)
     {
-        $club_manager = UFSC_Club_Manager::get_instance();
+        $club_manager = \UFSC\Clubs\ClubManager::get_instance();
         $club = $club_manager->get_club($club_id);
 
         if (!$club) {
@@ -230,7 +227,7 @@ class UFSC_Document_Manager
      */
     public function get_missing_documents($club_id)
     {
-        $club_manager = UFSC_Club_Manager::get_instance();
+        $club_manager = \UFSC\Clubs\ClubManager::get_instance();
         $club = $club_manager->get_club($club_id);
 
         if (!$club) {
@@ -293,7 +290,7 @@ class UFSC_Document_Manager
 
         // Update club status to 'Actif' (standardized status)
         // CORRECTION: Changed from 'valide' to 'Actif' to standardize club status throughout the plugin
-        $club_manager = UFSC_Club_Manager::get_instance();
+        $club_manager = \UFSC\Clubs\ClubManager::get_instance();
         $result = $club_manager->update_club($club_id, [
             'statut' => 'Actif',
             'date_affiliation' => current_time('mysql')

--- a/includes/admin/FrontendProSettings.php
+++ b/includes/admin/FrontendProSettings.php
@@ -1,15 +1,13 @@
 <?php
-/**
- * UFSC Frontend Pro Settings
- * Admin settings page for professional frontend features
- */
+
+namespace UFSC\Admin;
 
 // Exit if accessed directly
 if (!defined('ABSPATH')) {
     exit;
 }
 
-class UFSC_Frontend_Pro_Settings {
+class FrontendProSettings {
     
     /**
      * Initialize the settings
@@ -260,5 +258,5 @@ class UFSC_Frontend_Pro_Settings {
 
 // Initialize settings if in admin
 if (is_admin()) {
-    UFSC_Frontend_Pro_Settings::init();
+    \UFSC\Admin\FrontendProSettings::init();
 }

--- a/includes/admin/Menu.php
+++ b/includes/admin/Menu.php
@@ -5,21 +5,19 @@
  * Handles the admin menu setup for UFSC Gestion Club
  */
 
+namespace UFSC\Admin;
+
+use UFSC\Helpers\CSVExport;
+
 // Exit if accessed directly.
 if (!defined('ABSPATH')) {
     exit;
 }
 
-// Ensure class-dashboard.php exists before requiring it
-require_once plugin_dir_path(__FILE__) . 'class-dashboard.php';
-
-// Include UFSC CSV Export helper
-require_once plugin_dir_path(__FILE__) . '../helpers/class-ufsc-csv-export.php';
-
 /**
  * Menu Class
  */
-class UFSC_Menu
+class Menu
 {
     /**
      * Constructor
@@ -228,7 +226,7 @@ class UFSC_Menu
      */
     public function render_dashboard_page()
     {
-        $dashboard = new UFSC_Dashboard();
+        $dashboard = new \UFSC\Admin\Dashboard();
         $dashboard->render_dashboard();
     }
 
@@ -381,7 +379,7 @@ class UFSC_Menu
 
                 // Save club if no errors
                 if (empty($errors)) {
-                    $club_manager = UFSC_Club_Manager::get_instance();
+                    $club_manager = \UFSC\Clubs\ClubManager::get_instance();
                     $result = $club_manager->add_club($club_data);
 
                     if ($result) {
@@ -1213,9 +1211,9 @@ class UFSC_Menu
                     if (!empty($clubs)) {
 
                         // Use the new configurable CSV export
-                        UFSC_CSV_Export::export_clubs($clubs, 'clubs-selection-' . date('Y-m-d') . '.csv');
+                        \UFSC\Helpers\CSVExport::export_clubs($clubs, 'clubs-selection-' . date('Y-m-d') . '.csv');
 
-                        UFSC_CSV_Export::export_clubs($clubs, 'clubs_ufsc_selection_' . date('Y-m-d') . '.csv');
+                        \UFSC\Helpers\CSVExport::export_clubs($clubs, 'clubs_ufsc_selection_' . date('Y-m-d') . '.csv');
  
                     }
                 }
@@ -1229,9 +1227,9 @@ class UFSC_Menu
             if (!empty($clubs)) {
 
                 // Use the new configurable CSV export
-                UFSC_CSV_Export::export_clubs($clubs);
+                \UFSC\Helpers\CSVExport::export_clubs($clubs);
 
-                UFSC_CSV_Export::export_clubs($clubs, 'clubs_ufsc_complet_' . date('Y-m-d') . '.csv');
+                \UFSC\Helpers\CSVExport::export_clubs($clubs, 'clubs_ufsc_complet_' . date('Y-m-d') . '.csv');
             }
         }
         
@@ -1856,7 +1854,7 @@ class UFSC_Menu
         }
 
         // Get club data
-        $club_manager = UFSC_Club_Manager::get_instance();
+        $club_manager = \UFSC\Clubs\ClubManager::get_instance();
         $club = $club_manager->get_club($club_id);
         if (!$club) {
             echo '<div class="wrap"><div class="notice notice-error"><p>Club introuvable.</p></div></div>';
@@ -1910,14 +1908,14 @@ class UFSC_Menu
                         require_once(ABSPATH . 'wp-admin/includes/file.php');
                     }
                     
-                    $document_types = UFSC_Upload_Validator::get_allowed_document_types();
+                    $document_types = \UFSC\Helpers\UploadValidator::get_allowed_document_types();
                     
                     foreach ($document_types as $doc_key => $doc_label) {
                         if (!empty($_FILES[$doc_key]['name'])) {
                             $file = $_FILES[$doc_key];
                             
                             // Use centralized validation
-                            $validation = UFSC_Upload_Validator::validate_document($file, $club_id, $doc_key);
+                            $validation = \UFSC\Helpers\UploadValidator::validate_document($file, $club_id, $doc_key);
                             
                             if (is_wp_error($validation)) {
                                 $errors[] = 'Erreur pour ' . $doc_label . ': ' . $validation->get_error_message();
@@ -3005,7 +3003,7 @@ class UFSC_Menu
             }
             
             // Use the new configurable CSV export
-            UFSC_CSV_Export::export_licenses($licenses);
+            \UFSC\Helpers\CSVExport::export_licenses($licenses);
         }
     }
     /**
@@ -3127,7 +3125,7 @@ class UFSC_Menu
         
         // Use UFSC-compliant export
         $filename = 'licences_ufsc_' . date('Y-m-d') . '.csv';
-        UFSC_CSV_Export::export_licenses($rows, $filename);
+        \UFSC\Helpers\CSVExport::export_licenses($rows, $filename);
     }
 
     /**
@@ -3146,7 +3144,7 @@ class UFSC_Menu
         $edit_mode = isset($_GET['edit']) && $_GET['edit'] === '1';
 
         // Get club data
-        $club_manager = UFSC_Club_Manager::get_instance();
+        $club_manager = \UFSC\Clubs\ClubManager::get_instance();
         $club = $club_manager->get_club($club_id);
         if (!$club) {
             echo '<div class="wrap"><div class="notice notice-error"><p>Club introuvable.</p></div></div>';
@@ -3871,7 +3869,7 @@ class UFSC_Menu
         }
 
         // Get club data
-        $club_manager = UFSC_Club_Manager::get_instance();
+        $club_manager = \UFSC\Clubs\ClubManager::get_instance();
         $club = $club_manager->get_club($licence->club_id);
 
         // Handle form submission for license update (if in edit mode)

--- a/includes/admin/PackExports.php
+++ b/includes/admin/PackExports.php
@@ -1,7 +1,10 @@
 <?php
+
+namespace UFSC\Admin;
+
 if (!defined('ABSPATH')) { exit; }
 
-class UFSC_Pack_Exports_Admin {
+class PackExports {
     const OPT_KEY = 'ufsc_pack_settings';
 
     public function __construct() {
@@ -173,5 +176,5 @@ class UFSC_Pack_Exports_Admin {
 }
 
 if (is_admin()) {
-    new UFSC_Pack_Exports_Admin();
+    new \UFSC\Admin\PackExports();
 }

--- a/includes/admin/SyncMonitor.php
+++ b/includes/admin/SyncMonitor.php
@@ -1,12 +1,6 @@
 <?php
 
-/**
- * UFSC Sync Monitor Class
- * 
- * Provides synchronization monitoring and diagnostic tools
- * 
- * @package UFSC_Gestion_Club
- */
+namespace UFSC\Admin;
 
 // Exit if accessed directly.
 if (!defined('ABSPATH')) {
@@ -16,7 +10,7 @@ if (!defined('ABSPATH')) {
 /**
  * UFSC Sync Monitor Class
  */
-class UFSC_Sync_Monitor
+class SyncMonitor
 {
     /**
      * Singleton instance
@@ -568,4 +562,4 @@ class UFSC_Sync_Monitor
 }
 
 // Initialize the sync monitor
-UFSC_Sync_Monitor::get_instance();
+\UFSC\Admin\SyncMonitor::get_instance();

--- a/includes/admin/TestHelper.php
+++ b/includes/admin/TestHelper.php
@@ -1,12 +1,6 @@
 <?php
 
-/**
- * Test Helper Class
- *
- * Provides testing utilities for the UFSC document management system
- *
- * @package UFSC_Gestion_Club
- */
+namespace UFSC\Admin;
 
 // Exit if accessed directly.
 if (!defined('ABSPATH')) {
@@ -16,7 +10,7 @@ if (!defined('ABSPATH')) {
 /**
  * Test Helper Class
  */
-class UFSC_Test_Helper
+class TestHelper
 {
     /**
      * Singleton instance
@@ -26,7 +20,7 @@ class UFSC_Test_Helper
     /**
      * Get singleton instance
      *
-     * @return UFSC_Test_Helper
+     * @return \UFSC\Admin\TestHelper
      */
     public static function get_instance()
     {
@@ -64,8 +58,8 @@ class UFSC_Test_Helper
         ];
 
         $required_classes = [
-            'UFSC_Club_Manager',
-            'UFSC_Document_Manager'
+            '\UFSC\Clubs\ClubManager',
+            '\UFSC\Admin\DocumentManager'
         ];
 
         foreach ($required_classes as $class) {
@@ -143,7 +137,7 @@ class UFSC_Test_Helper
         ];
 
         try {
-            $doc_manager = UFSC_Document_Manager::get_instance();
+            $doc_manager = \UFSC\Admin\DocumentManager::get_instance();
             $tests['document_manager']['details'][] = "✓ Instance du gestionnaire créée";
 
             // Test secure link generation
@@ -227,7 +221,7 @@ class UFSC_Test_Helper
             return false;
         }
 
-        $club_manager = UFSC_Club_Manager::get_instance();
+        $club_manager = \UFSC\Clubs\ClubManager::get_instance();
         
         $test_data = [
             'nom' => 'Club Test UFSC - ' . date('Y-m-d H:i:s'),

--- a/includes/admin/test-sync.php
+++ b/includes/admin/test-sync.php
@@ -29,7 +29,7 @@ function ufsc_run_sync_tests() {
     $test_results['logging_function'] = function_exists('ufsc_log_operation');
 
     // Test 4: Check if sync monitor class is loaded
-    $test_results['sync_monitor'] = class_exists('UFSC_Sync_Monitor');
+    $test_results['sync_monitor'] = class_exists('\UFSC\Admin\SyncMonitor');
 
     // Test 5: Check database tables
     global $wpdb;

--- a/includes/class-ufsc-woocommerce-integration.php
+++ b/includes/class-ufsc-woocommerce-integration.php
@@ -223,8 +223,8 @@ class UFSC_WooCommerce_Integration {
      */
     private function fallback_activate_affiliation($club_id, $order) {
         // Try to get club manager
-        if (class_exists('UFSC_Club_Manager')) {
-            $club_manager = UFSC_Club_Manager::get_instance();
+        if (class_exists('\UFSC\Clubs\ClubManager')) {
+            $club_manager = \UFSC\Clubs\ClubManager::get_instance();
             $club = $club_manager->get_club($club_id);
 
             if ($club) {
@@ -374,8 +374,8 @@ class UFSC_WooCommerce_Integration {
         }
         
         // Get club data to retrieve leader information
-        if (class_exists('UFSC_Club_Manager')) {
-            $club_manager = UFSC_Club_Manager::get_instance();
+        if (class_exists('\UFSC\Clubs\ClubManager')) {
+            $club_manager = \UFSC\Clubs\ClubManager::get_instance();
             $club = $club_manager->get_club($club_id);
             
             if ($club) {

--- a/includes/clubs/ClubManager.php
+++ b/includes/clubs/ClubManager.php
@@ -1,12 +1,6 @@
 <?php
 
-/**
- * Club Manager Class
- *
- * Handles operations related to clubs
- *
- * @package UFSC_Gestion_Club
- */
+namespace UFSC\Clubs;
 
 // Exit if accessed directly.
 if (! defined('ABSPATH')) {
@@ -16,7 +10,7 @@ if (! defined('ABSPATH')) {
 /**
  * Club Manager Class
  */
-class UFSC_Club_Manager
+class ClubManager
 {
     /**
      * Database table name
@@ -31,7 +25,7 @@ class UFSC_Club_Manager
     /**
      * Get singleton instance
      *
-     * @return UFSC_Club_Manager
+     * @return ClubManager
      */
     public static function get_instance()
     {

--- a/includes/clubs/form-club.php
+++ b/includes/clubs/form-club.php
@@ -18,7 +18,7 @@ function ufsc_render_club_form($club_id = 0, $is_frontend = false, $is_affiliati
     // Récupérer le club si en mode édition
     $club = null;
     if ($club_id > 0) {
-        $club_manager = UFSC_Club_Manager::get_instance();
+        $club_manager = \UFSC\Clubs\ClubManager::get_instance();
         $club = $club_manager->get_club($club_id);
     }
 
@@ -150,7 +150,7 @@ function ufsc_render_club_form($club_id = 0, $is_frontend = false, $is_affiliati
 
             // Si pas d'erreurs, enregistrer le club
             if (empty($errors)) {
-                $club_manager = UFSC_Club_Manager::get_instance();
+                $club_manager = \UFSC\Clubs\ClubManager::get_instance();
 
                 if ($is_edit) {
                     $result = $club_manager->update_club($club_id, $club_data);

--- a/includes/controllers/save-club.php
+++ b/includes/controllers/save-club.php
@@ -148,7 +148,7 @@ function ufsc_handle_club_submission()
     // 🎫 Création automatique des 3 licences incluses (si nouvelle insertion)
     if (!$is_edit) {
         require_once plugin_dir_path(__FILE__) . '/../clubs/class-club-manager.php';
-        $manager = UFSC_Club_Manager::get_instance();
+        $manager = \UFSC\Clubs\ClubManager::get_instance();
 
         $licences_table = $wpdb->prefix . 'ufsc_licences';
         $now = current_time('mysql');

--- a/includes/core/GestionClubCore.php
+++ b/includes/core/GestionClubCore.php
@@ -1,14 +1,18 @@
 <?php
 
+namespace UFSC\Core;
+
+use UFSC\Clubs\ClubManager;
+
 if (!defined('ABSPATH')) {
     exit; // 🔐 Sécurité : blocage de l'accès direct
 }
 
-class UFSC_GestionClub_Core
+class GestionClubCore
 {
     /**
      * Instance du gestionnaire de clubs
-     * @var UFSC_Club_Manager
+     * @var ClubManager
      */
     private static $club_manager;
 
@@ -25,17 +29,16 @@ class UFSC_GestionClub_Core
         );
 
         // 🧩 Inclusion des classes
-        require_once UFSC_PLUGIN_PATH . 'includes/clubs/class-club-manager.php';
         require_once UFSC_PLUGIN_PATH . 'includes/clubs/admin-club-list-page.php';
 
-        if (!class_exists('UFSC_Club_Manager')) {
+        if (!class_exists(ClubManager::class)) {
             return;
         }
 
-        self::$club_manager = UFSC_Club_Manager::get_instance();
+        self::$club_manager = ClubManager::get_instance();
 
         // ⚙️ Hooks
-        // Note: Admin menu is handled by UFSC_Menu class to avoid duplication
+        // Note: Admin menu is handled by \UFSC\Admin\Menu class to avoid duplication
         // The register_admin_menu method below is kept for legacy/backup purposes
         // add_action('admin_menu', [self::class, 'register_admin_menu']);
         add_action('init', [self::class, 'register_post_types']);
@@ -77,7 +80,7 @@ class UFSC_GestionClub_Core
             [self::class, 'render_add_club_page']
         );
 
-        // Note: Licence menu items moved to UFSC_Menu class to avoid duplication
+        // Note: Licence menu items moved to \UFSC\Admin\Menu class to avoid duplication
 
         // Sous-menu : Paramètres
         add_submenu_page(

--- a/includes/frontend/affiliation-woocommerce.php
+++ b/includes/frontend/affiliation-woocommerce.php
@@ -33,7 +33,7 @@ if (!function_exists('ufsc_add_affiliation_to_cart')) {
         WC()->cart->empty_cart();
 
         // Récupérer les informations du club
-        $club_manager = UFSC_Club_Manager::get_instance();
+        $club_manager = \UFSC\Clubs\ClubManager::get_instance();
         $club = $club_manager->get_club($club_id);
 
         if (!$club) {
@@ -109,7 +109,7 @@ if (!function_exists('ufsc_process_affiliation_order')) {
 
                 if ($club_id) {
                     // Mettre à jour le club comme "En attente de validation"
-                    $club_manager = UFSC_Club_Manager::get_instance();
+                    $club_manager = \UFSC\Clubs\ClubManager::get_instance();
                     $club = $club_manager->get_club($club_id);
 
                     if ($club) {

--- a/includes/frontend/club/attestations.php
+++ b/includes/frontend/club/attestations.php
@@ -170,7 +170,7 @@ function ufsc_render_licence_attestations($club)
                 </div>';
 
     // Get club licenses - only show validated licenses
-    $club_manager = UFSC_Club_Manager::get_instance();
+    $club_manager = \UFSC\Clubs\ClubManager::get_instance();
     $licences = $club_manager->get_licences_by_club($club->id);
     $validated_licences = array_filter($licences, function($licence) {
         return isset($licence->statut) && $licence->statut === 'validee';

--- a/includes/frontend/club/club-infos.php
+++ b/includes/frontend/club/club-infos.php
@@ -221,7 +221,7 @@ function ufsc_club_render_home($club)
     $output .= '</div>';
 
     // Get license statistics
-    $club_manager = UFSC_Club_Manager::get_instance();
+    $club_manager = \UFSC\Clubs\ClubManager::get_instance();
     $licences = $club_manager->get_licences_by_club($club->id);
     $stats = ufsc_calculate_licence_stats($licences, $club);
 
@@ -306,7 +306,7 @@ function ufsc_handle_contact_update($club)
     }
 
     // Update the field
-    $club_manager = UFSC_Club_Manager::get_instance();
+    $club_manager = \UFSC\Clubs\ClubManager::get_instance();
     $success = $club_manager->update_club_field($club_id, $field_name, $new_value);
 
     if ($success) {

--- a/includes/frontend/club/documents.php
+++ b/includes/frontend/club/documents.php
@@ -416,7 +416,7 @@ function ufsc_handle_attestation_download()
     }
 
     // Get club data
-    $club_manager = UFSC_Club_Manager::get_instance();
+    $club_manager = \UFSC\Clubs\ClubManager::get_instance();
     $club = $club_manager->get_club($club_id);
 
     if (!$club) {
@@ -467,7 +467,7 @@ function ufsc_handle_document_download()
     }
 
     // Get club data
-    $club_manager = UFSC_Club_Manager::get_instance();
+    $club_manager = \UFSC\Clubs\ClubManager::get_instance();
     $club = $club_manager->get_club($club_id);
 
     if (!$club) {
@@ -726,7 +726,7 @@ function ufsc_process_document_update()
     }
 
     $club = $access_check['club'];
-    $club_manager = UFSC_Club_Manager::get_instance();
+    $club_manager = \UFSC\Clubs\ClubManager::get_instance();
 
     // Document fields mapping
     $doc_fields = [

--- a/includes/frontend/dashboard/overview.php
+++ b/includes/frontend/dashboard/overview.php
@@ -261,7 +261,7 @@ function ufsc_render_documents_section($club) {
  * @return string HTML output
  */
 function ufsc_render_licences_section($club, $limit = 10) {
-    $club_manager = UFSC_Club_Manager::get_instance();
+    $club_manager = \UFSC\Clubs\ClubManager::get_instance();
     $licences = $club_manager->get_licences_by_club($club->id);
     
     // Calculate statistics

--- a/includes/frontend/helpers/dashboard-data.php
+++ b/includes/frontend/helpers/dashboard-data.php
@@ -20,7 +20,7 @@ function ufsc_get_club_stats($club_id) {
     global $wpdb;
     
     // Safety check for club manager
-    if (!class_exists('UFSC_Club_Manager')) {
+    if (!class_exists('\UFSC\Clubs\ClubManager')) {
         return [
             'total_licences' => 0,
             'active_licences' => 0,
@@ -29,7 +29,7 @@ function ufsc_get_club_stats($club_id) {
         ];
     }
     
-    $club_manager = UFSC_Club_Manager::get_instance();
+    $club_manager = \UFSC\Clubs\ClubManager::get_instance();
     $club = $club_manager->get_club($club_id);
     $licences = $club_manager->get_licences_by_club($club_id);
     
@@ -72,7 +72,7 @@ function ufsc_get_club_stats($club_id) {
  */
 function ufsc_get_club_detailed_stats($club_id) {
     // Safety check for club manager
-    if (!class_exists('UFSC_Club_Manager')) {
+    if (!class_exists('\UFSC\Clubs\ClubManager')) {
         return [
             'total_licences' => 0,
             'by_gender' => ['M' => 0, 'F' => 0],
@@ -88,7 +88,7 @@ function ufsc_get_club_detailed_stats($club_id) {
         ];
     }
     
-    $club_manager = UFSC_Club_Manager::get_instance();
+    $club_manager = \UFSC\Clubs\ClubManager::get_instance();
     $licences = $club_manager->get_licences_by_club($club_id);
     
     $stats = [
@@ -139,7 +139,7 @@ function ufsc_get_quota_pack_info($club_id) {
     global $wpdb;
     
     // Safety check for club manager
-    if (!class_exists('UFSC_Club_Manager')) {
+    if (!class_exists('\UFSC\Clubs\ClubManager')) {
         return [
             'quota_total' => 10,
             'inclus_used' => 0,
@@ -150,7 +150,7 @@ function ufsc_get_quota_pack_info($club_id) {
         ];
     }
     
-    $club_manager = UFSC_Club_Manager::get_instance();
+    $club_manager = \UFSC\Clubs\ClubManager::get_instance();
     $club = $club_manager->get_club($club_id);
     $licences = $club_manager->get_licences_by_club($club_id);
     

--- a/includes/frontend/helpers/logo-upload.php
+++ b/includes/frontend/helpers/logo-upload.php
@@ -69,10 +69,10 @@ function ufsc_process_club_logo_upload()
     }
 
     $club = $access_check['club'];
-    if (!class_exists('UFSC_Club_Manager')) {
+    if (!class_exists('\UFSC\Clubs\ClubManager')) {
         wp_die('Service indisponible', 'Erreur', ['response' => 500]);
     }
-    $club_manager = UFSC_Club_Manager::get_instance();
+    $club_manager = \UFSC\Clubs\ClubManager::get_instance();
 
     // Fichier présent ?
     if (empty($_FILES['club_logo']['name'])) {

--- a/includes/frontend/parts/club-infos.php
+++ b/includes/frontend/parts/club-infos.php
@@ -5,7 +5,7 @@ if (! defined('ABSPATH')) {
 
 // Chargement de la classe via le singleton
 require_once plugin_dir_path(__FILE__) . '../clubs/class-club-manager.php';
-$manager = UFSC_Club_Manager::get_instance();
+$manager = \UFSC\Clubs\ClubManager::get_instance();
 
 // Récupère l’ID du club de l’utilisateur
 $user_id = get_current_user_id();

--- a/includes/frontend/shortcodes/affiliation-form-shortcode.php
+++ b/includes/frontend/shortcodes/affiliation-form-shortcode.php
@@ -106,7 +106,7 @@ if (!function_exists('ufsc_process_affiliation_order')) {
 
             if ($club_id && $affiliation_type === 'new_club') {
                 // Mettre à jour le club comme "En attente de validation"
-                $club_manager = UFSC_Club_Manager::get_instance();
+                $club_manager = \UFSC\Clubs\ClubManager::get_instance();
                 $club = $club_manager->get_club($club_id);
 
                 if ($club) {

--- a/includes/frontend/shortcodes/ajouter-licencie-shortcode.php
+++ b/includes/frontend/shortcodes/ajouter-licencie-shortcode.php
@@ -143,7 +143,7 @@ function ufsc_render_ajax_licensee_form($club)
  */
 function ufsc_render_quota_information($club)
 {
-    $club_manager = UFSC_Club_Manager::get_instance();
+    $club_manager = \UFSC\Clubs\ClubManager::get_instance();
     $licences = $club_manager->get_licences_by_club($club->id);
     $quota_total = intval($club->quota_licences);
     $licences_count = count($licences);

--- a/includes/frontend/shortcodes/licence-button-shortcode.php
+++ b/includes/frontend/shortcodes/licence-button-shortcode.php
@@ -28,7 +28,7 @@ function ufsc_bouton_licence_shortcode($atts)
     }
 
     // Récupérer le nombre de licences
-    $club_manager = UFSC_Club_Manager::get_instance();
+    $club_manager = \UFSC\Clubs\ClubManager::get_instance();
     $licences = $club_manager->get_licences_by_club($club->id);
     $quota_total = intval($club->quota_licences);
     $licences_count = count($licences);

--- a/includes/frontend/shortcodes/recent-licences-shortcode.php
+++ b/includes/frontend/shortcodes/recent-licences-shortcode.php
@@ -44,7 +44,7 @@ function ufsc_recent_licences_shortcode($atts = array()) {
     }
     
     // Get club manager instance
-    $club_manager = UFSC_Club_Manager::get_instance();
+    $club_manager = \UFSC\Clubs\ClubManager::get_instance();
     if (!$club_manager) {
         return '<div class="ufsc-alert ufsc-alert-error"><p>' . __('Erreur : impossible de charger les données.', 'plugin-ufsc-gestion-club-13072025') . '</p></div>';
     }

--- a/includes/frontend/woocommerce-affiliation-form.php
+++ b/includes/frontend/woocommerce-affiliation-form.php
@@ -245,7 +245,7 @@ add_action('woocommerce_order_status_processing', 'ufsc_process_affiliation_afte
  */
 function ufsc_create_or_update_club_from_order_item($item, $order)
 {
-    $club_manager = UFSC_Club_Manager::get_instance();
+    $club_manager = \UFSC\Clubs\ClubManager::get_instance();
     
     // Get affiliation data from order item meta
     $club_data = [

--- a/includes/frontend/woocommerce-licence-form.php
+++ b/includes/frontend/woocommerce-licence-form.php
@@ -282,7 +282,7 @@ function ufsc_apply_quota_discount($cart)
     }
 
     // Vérifier si le club a encore du quota
-    $club_manager = UFSC_Club_Manager::get_instance();
+    $club_manager = \UFSC\Clubs\ClubManager::get_instance();
     $club = $club_manager->get_club($club_id);
 
     if (!$club) {
@@ -332,7 +332,7 @@ function ufsc_process_licence_order($order_id)
 
             if ($club_id && $licence_data) {
                 // Créer la licence dans la base de données
-                $club_manager = UFSC_Club_Manager::get_instance();
+                $club_manager = \UFSC\Clubs\ClubManager::get_instance();
 
                 // Compléter les données de licence
                 $licence_data['club_id'] = $club_id;
@@ -470,7 +470,7 @@ function ufsc_process_licence_order_enhanced($order_id) {
         return;
     }
 
-    $club_manager = UFSC_Club_Manager::get_instance();
+    $club_manager = \UFSC\Clubs\ClubManager::get_instance();
 
     foreach ($order->get_items() as $item) {
         $product_id = $item->get_product_id();
@@ -558,7 +558,7 @@ function ufsc_handle_order_cancellation($order_id) {
         return;
     }
 
-    $club_manager = UFSC_Club_Manager::get_instance();
+    $club_manager = \UFSC\Clubs\ClubManager::get_instance();
 
     foreach ($order->get_items() as $item) {
         $licence_id = $item->get_meta('ufsc_licence_id');

--- a/includes/helpers/CSVExport.php
+++ b/includes/helpers/CSVExport.php
@@ -1,13 +1,6 @@
 <?php
-/**
- * UFSC CSV Export Helper Class
- *
- * Handles CSV exports in compliance with UFSC templates:
- * - Semicolon separator (;) instead of comma
- * - Proper HTTP headers to prevent HTML contamination
- * - UFSC-compliant column structure
- * - Status filtering support
- */
+
+namespace UFSC\Helpers;
 
 // Exit if accessed directly.
 if (!defined('ABSPATH')) {
@@ -17,7 +10,7 @@ if (!defined('ABSPATH')) {
 /**
  * UFSC CSV Export Class
  */
-class UFSC_CSV_Export
+class CSVExport
 {
     /**
      * Export clubs in UFSC-compliant format

--- a/includes/helpers/UploadValidator.php
+++ b/includes/helpers/UploadValidator.php
@@ -1,12 +1,6 @@
 <?php
 
-/**
- * UFSC Upload Validator
- *
- * Centralized file upload validation for club documents
- *
- * @package UFSC_Gestion_Club
- */
+namespace UFSC\Helpers;
 
 // Exit if accessed directly.
 if (!defined('ABSPATH')) {
@@ -91,7 +85,7 @@ function ufsc_validate_club_document_upload($file, $club_id, $doc_type) {
  * 
  * Static class for centralized upload validation
  */
-class UFSC_Upload_Validator {
+class UploadValidator {
     
     /**
      * Validate club document upload

--- a/includes/licences/admin-licence-list.php
+++ b/includes/licences/admin-licence-list.php
@@ -156,7 +156,7 @@ if (isset($_GET['export_csv']) && check_admin_referer('ufsc_export_licences_' . 
 
     // Use UFSC-compliant export
     $filename = 'licences_' . sanitize_file_name($club->nom) . '_' . date('Y-m-d') . '.csv';
-    UFSC_CSV_Export::export_licenses($rows, $filename);
+    \UFSC\Helpers\CSVExport::export_licenses($rows, $filename);
 }
 
 // Get filtered license data using the filter system

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -274,7 +274,7 @@ function ufsc_render_club_attestation($atts = [])
 function ufsc_render_liste_clubs($atts = [])
 {
     // Récupérer tous les clubs affiliés
-    $club_manager = UFSC_Club_Manager::get_instance();
+    $club_manager = \UFSC\Clubs\ClubManager::get_instance();
     $all_clubs = $club_manager->get_clubs();
     
     // Filtrer pour ne garder que les clubs validés/actifs

--- a/includes/tests/admin-settings-test.php
+++ b/includes/tests/admin-settings-test.php
@@ -18,10 +18,10 @@ function test_ufsc_admin_settings() {
     $results = [];
     
     // Test 1: Check if admin settings class exists
-    if (class_exists('UFSC_Admin_Settings')) {
-        $results['admin_class'] = 'PASS - UFSC_Admin_Settings class exists';
+    if (class_exists('\UFSC\Admin\AdminSettings')) {
+        $results['admin_class'] = 'PASS - \UFSC\Admin\AdminSettings class exists';
     } else {
-        $results['admin_class'] = 'FAIL - UFSC_Admin_Settings class not found';
+        $results['admin_class'] = 'FAIL - \UFSC\Admin\AdminSettings class not found';
     }
     
     // Test 2: Test default option values
@@ -63,8 +63,8 @@ function test_ufsc_admin_settings() {
     }
     
     // Test 4: Test CSV sanitization (if admin class is available)
-    if (class_exists('UFSC_Admin_Settings')) {
-        $admin_settings = new UFSC_Admin_Settings();
+    if (class_exists('\UFSC\Admin\AdminSettings')) {
+        $admin_settings = new \UFSC\Admin\AdminSettings();
         
         // Test valid CSV
         $test_csv = '2934, 2935, 2936';

--- a/includes/tests/database-schema-test.php
+++ b/includes/tests/database-schema-test.php
@@ -251,8 +251,8 @@ class UFSC_Database_Schema_Test
      */
     public static function trigger_table_creation()
     {
-        if (class_exists('UFSC_Club_Manager')) {
-            $manager = UFSC_Club_Manager::get_instance();
+        if (class_exists('\UFSC\Clubs\ClubManager')) {
+            $manager = \UFSC\Clubs\ClubManager::get_instance();
             $manager->create_table();
             return true;
         }

--- a/includes/tests/woocommerce-ecommerce-test.php
+++ b/includes/tests/woocommerce-ecommerce-test.php
@@ -186,10 +186,10 @@ function ufsc_test_admin_settings_methods() {
         'errors' => []
     ];
     
-    // Check if UFSC_Admin_Settings class exists
-    if (!class_exists('UFSC_Admin_Settings')) {
+    // Check if \UFSC\Admin\AdminSettings class exists
+    if (!class_exists('\UFSC\Admin\AdminSettings')) {
         $test['passed'] = false;
-        $test['errors'][] = 'UFSC_Admin_Settings class not found';
+        $test['errors'][] = '\UFSC\Admin\AdminSettings class not found';
         return $test;
     }
     
@@ -202,9 +202,9 @@ function ufsc_test_admin_settings_methods() {
     ];
     
     foreach ($methods_to_check as $method) {
-        if (!method_exists('UFSC_Admin_Settings', $method)) {
+        if (!method_exists('\UFSC\Admin\AdminSettings', $method)) {
             $test['passed'] = false;
-            $test['errors'][] = "Method $method not found in UFSC_Admin_Settings";
+            $test['errors'][] = "Method $method not found in \UFSC\Admin\AdminSettings";
         }
     }
     

--- a/includes/views/admin-club-list.php
+++ b/includes/views/admin-club-list.php
@@ -24,7 +24,7 @@ if (isset($_POST['export_selected']) && isset($_POST['selected_clubs']) && is_ar
         ));
         
         if (!empty($clubs)) {
-            UFSC_CSV_Export::export_clubs($clubs, 'clubs_ufsc_selection_' . gmdate('Y-m-d') . '.csv');
+            \UFSC\Helpers\CSVExport::export_clubs($clubs, 'clubs_ufsc_selection_' . gmdate('Y-m-d') . '.csv');
         }
     }
 }
@@ -186,7 +186,7 @@ $base_url = remove_query_arg('paged', isset($_SERVER['REQUEST_URI']) ? wp_unslas
                 <tbody>
                     <?php 
                     // Initialize document manager to check document status
-                    $doc_manager = UFSC_Document_Manager::get_instance();
+                    $doc_manager = \UFSC\Admin\DocumentManager::get_instance();
                     
                     foreach ($clubs as $club): 
                         // Check document status

--- a/includes/woocommerce/auto-order-admin-licences.php
+++ b/includes/woocommerce/auto-order-admin-licences.php
@@ -87,7 +87,7 @@ class UFSC_Auto_Order_Admin_Licences {
         
         // Get club data to find the responsible user
         require_once UFSC_PLUGIN_PATH . 'includes/clubs/class-club-manager.php';
-        $club_manager = UFSC_Club_Manager::get_instance();
+        $club_manager = \UFSC\Clubs\ClubManager::get_instance();
         $club = $club_manager->get_club($licence->club_id);
         
         // Create WooCommerce order

--- a/tests/phpunit/test-ufsc-wc-handler.php
+++ b/tests/phpunit/test-ufsc-wc-handler.php
@@ -27,7 +27,7 @@ class Test_UFSC_WC_Handler extends WP_UnitTestCase
         parent::setUp();
         
         // Ensure UFSC plugin classes are loaded
-        if (!class_exists('UFSC_Club_Manager')) {
+        if (!class_exists('\UFSC\Clubs\ClubManager')) {
             $this->markTestSkipped('UFSC plugin classes not available');
         }
     }


### PR DESCRIPTION
## Summary
- introduce Composer PSR-4 autoload configuration
- namespace core and admin classes and update references
- load classes via Composer autoloader in main plugin

## Testing
- `php -l Plugin_UFSC_GESTION_CLUB_13072025.php`
- `php -l includes/admin/Menu.php`
- `composer dump-autoload`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68adf4abb550832b8fe498f0fbdbd129