### PR TITLE
Refactor club access verification

### DIFF
--- a/includes/frontend/club/club-infos.php
+++ b/includes/frontend/club/club-infos.php
@@ -623,22 +623,3 @@ function ufsc_get_licence_status_info($licence)
         'text' => $status_text
     ];
 }
-
-/**
- * Verify club access for current user
- *
- * @param int $club_id Club ID to verify access for
- * @return bool True if user has access to this club
- */
-function ufsc_verify_club_access($club_id)
-{
-    if (!is_user_logged_in()) {
-        return false;
-    }
-
-    $user_id = get_current_user_id();
-    $user_club = ufsc_get_user_club($user_id);
-
-    // Check if user's club matches the requested club
-    return $user_club && (int) $user_club->id === (int) $club_id;
-}

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -110,6 +110,24 @@ function ufsc_get_user_club($user_id = null)
 }
 
 /**
+ * Vérifie si l'utilisateur courant a accès au club spécifié
+ *
+ * @param int $club_id Identifiant du club à vérifier
+ * @return bool True si l'utilisateur est associé à ce club
+ */
+function ufsc_verify_club_access($club_id)
+{
+    if (!$club_id || !is_user_logged_in()) {
+        return false;
+    }
+
+    $user_id   = get_current_user_id();
+    $user_club = ufsc_get_user_club($user_id);
+
+    return $user_club && (int) $user_club->id === (int) $club_id;
+}
+
+/**
  * Safely check user capabilities without causing fatal errors
  * This function ensures WordPress is fully loaded before checking capabilities
  *


### PR DESCRIPTION
## Summary
- move `ufsc_verify_club_access` into global helpers and load it during plugin init
- restrict `club_id` GET overrides to admins
- always validate club access when rendering club licences and show "Club introuvable pour ce compte" on failure

## Testing
- `php -l includes/helpers.php`
- `php -l includes/frontend/club/club-infos.php`
- `php -l includes/overrides/club-licenses-override.php`


------
https://chatgpt.com/codex/tasks/task_e_68ae0c7792d4832b9606b97844f73a8e