### PR TITLE
Add logout option to logged-in message

### DIFF
--- a/includes/frontend/shortcodes/login-register-shortcode.php
+++ b/includes/frontend/shortcodes/login-register-shortcode.php
@@ -80,21 +80,37 @@ function ufsc_login_register_shortcode($atts = array()) {
  * @return string HTML output
  */
 function ufsc_render_logged_in_message() {
-    $current_user = wp_get_current_user();
+    $current_user  = wp_get_current_user();
     $dashboard_url = ufsc_get_dashboard_url();
-    
-    $output = '<div class="ufsc-card">';
+
+    // Determine redirect target for logout if provided
+    $logout_redirect = '';
+    if (isset($_REQUEST['redirect_to'])) {
+        $logout_redirect = esc_url_raw($_REQUEST['redirect_to']);
+    } elseif (isset($_REQUEST['redirect'])) {
+        $logout_redirect = esc_url_raw($_REQUEST['redirect']);
+    } else {
+        $logout_redirect = get_permalink();
+    }
+
+    $logout_url = wp_logout_url($logout_redirect);
+
+    $output  = '<div class="ufsc-card">';
     $output .= '<h3>' . __('Déjà connecté', 'plugin-ufsc-gestion-club-13072025') . '</h3>';
     $output .= '<p>' . sprintf(__('Bonjour %s, vous êtes déjà connecté.', 'plugin-ufsc-gestion-club-13072025'), esc_html($current_user->display_name)) . '</p>';
-    
+
     if ($dashboard_url) {
         $output .= '<a href="' . esc_url($dashboard_url) . '" class="ufsc-btn ufsc-btn-primary">';
         $output .= __('Accéder au tableau de bord', 'plugin-ufsc-gestion-club-13072025');
         $output .= '</a>';
     }
-    
+
+    $output .= '<a href="' . esc_url($logout_url) . '" class="ufsc-btn ufsc-btn-secondary">';
+    $output .= __('Se déconnecter', 'plugin-ufsc-gestion-club-13072025');
+    $output .= '</a>';
+
     $output .= '</div>';
-    
+
     return $output;
 }
 


### PR DESCRIPTION
## Summary
- add logout button to logged-in message using `wp_logout_url`
- support redirect parameters when logging out

## Testing
- `php -l includes/frontend/shortcodes/login-register-shortcode.php`


------
https://chatgpt.com/codex/tasks/task_e_68ae16fed24c832b9616e2b8a4a2b767