### PR TITLE
Expose Connexion Club login page in public navigation

### DIFF
--- a/includes/admin/ufsc-page-creator.php
+++ b/includes/admin/ufsc-page-creator.php
@@ -155,3 +155,22 @@ add_action('admin_init', 'ufsc_admin_init_page_check');
 if (defined('UFSC_PLUGIN_MAIN_FILE')) {
     register_activation_hook(UFSC_PLUGIN_MAIN_FILE, 'ufsc_ensure_frontend_pages');
 }
+
+/**
+ * Retrieve the URL of the automatically created "Connexion Club" page.
+ *
+ * This helper ensures other components can easily link to the login page
+ * created by this module.
+ *
+ * @return string|false The URL of the login page or false if it doesn't exist.
+ * @since 1.3.0
+ */
+function ufsc_get_login_page_url() {
+    $page_id = (int) get_option('ufsc_login_page_id', 0);
+
+    if ($page_id && get_post_status($page_id) === 'publish') {
+        return get_permalink($page_id);
+    }
+
+    return false;
+}

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -1046,3 +1046,57 @@ function ufsc_get_asset(string $file): array {
         'version' => file_exists($path) ? filemtime($path) : null,
     ];
 }
+
+/**
+ * Append a "Connexion Club" link to navigation menus for guests.
+ *
+ * The login page is automatically created by the plugin. This filter makes
+ * the link visible in public navigation while keeping it hidden for logged-in
+ * users to avoid confusion.
+ *
+ * @param string $items Existing HTML list items.
+ * @param object $args  Menu arguments (unused).
+ * @return string Modified menu items.
+ */
+function ufsc_add_login_link_to_menus($items, $args) {
+    // Only show to visitors.
+    if (is_user_logged_in()) {
+        return $items;
+    }
+
+    // Get URL of login page created during setup.
+    $login_url = function_exists('ufsc_get_login_page_url') ? ufsc_get_login_page_url() : false;
+
+    if (!$login_url) {
+        return $items;
+    }
+
+    $items .= '<li class="menu-item ufsc-login-menu-item"><a href="' . esc_url($login_url) . '">' . esc_html__('Connexion Club', 'plugin-ufsc-gestion-club-13072025') . '</a></li>';
+
+    return $items;
+}
+add_filter('wp_nav_menu_items', 'ufsc_add_login_link_to_menus', 10, 2);
+
+/**
+ * Shortcode to render a link to the "Connexion Club" page for guests.
+ *
+ * Usage: [ufsc_login_link]
+ *
+ * @return string HTML link or empty string when user is logged in or page
+ *                does not exist.
+ */
+function ufsc_login_link_shortcode() {
+    if (is_user_logged_in()) {
+        return '';
+    }
+
+    $login_url = function_exists('ufsc_get_login_page_url') ? ufsc_get_login_page_url() : false;
+
+    if (!$login_url) {
+        return '';
+    }
+
+    return '<a class="ufsc-login-link" href="' . esc_url($login_url) . '">' . esc_html__('Connexion Club', 'plugin-ufsc-gestion-club-13072025') . '</a>';
+}
+add_shortcode('ufsc_login_link', 'ufsc_login_link_shortcode');
+


### PR DESCRIPTION
## Summary
- add helper to retrieve automatically created "Connexion Club" page URL
- append login link to WordPress menus for guests and provide shortcode option

## Testing
- `php -l includes/admin/ufsc-page-creator.php`
- `php -l includes/helpers.php`
- `npm run build` *(fails: Invalid value for option "output.inlineDynamicImports" - multiple inputs are not supported when "output.inlineDynamicImports" is true)*
- `phpunit` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae170ff62c832baab54e2cc084a388