### PR TITLE
chore: update affiliation product ID

### DIFF
--- a/DOC_FRONTEND_SHORTCODES.md
+++ b/DOC_FRONTEND_SHORTCODES.md
@@ -118,7 +118,7 @@ Formulaire d'affiliation club (version standalone).
 ## Fonctionnalités Techniques
 
 ### Intégration WooCommerce
-- Les formulaires `ufsc_licence_form` et `ufsc_affiliation_form` s'intègrent automatiquement aux produits WooCommerce (IDs 2933 et 2934)
+- Les formulaires `ufsc_licence_form` et `ufsc_affiliation_form` s'intègrent automatiquement aux produits WooCommerce (IDs 4823 et 2934)
 - Gestion automatique du panier avec métadonnées
 - Synchronisation des statuts commande ↔ licence
 - Prévention des doublons et gestion des quotas
@@ -145,7 +145,7 @@ Formulaire d'affiliation club (version standalone).
 
 ### Options Plugin
 - `ufsc_licence_product_id` : ID du produit WooCommerce pour les licences (défaut: 2934)
-- `ufsc_affiliation_product_id` : ID du produit WooCommerce pour les affiliations (défaut: 2933)
+- `ufsc_affiliation_product_id` : ID du produit WooCommerce pour les affiliations (défaut: 4823)
 - `ufsc_manual_validation` : Active la validation manuelle des licences (défaut: false)
 - `ufsc_club_form_page_id` : ID de la page contenant le shortcode `[ufsc_formulaire_club]`
 

--- a/IMPLEMENTATION_COMPLETE.md
+++ b/IMPLEMENTATION_COMPLETE.md
@@ -16,7 +16,7 @@ This document confirms that all requirements from the task have been successfull
 **Status: CREATED**
 - ✅ Admin page under Settings → UFSC (`add_options_page`)
 - ✅ Required fields with correct defaults:
-  - `ufsc_wc_affiliation_product_id` (int, default: 2933)
+  - `ufsc_wc_affiliation_product_id` (int, default: 4823)
   - `ufsc_wc_license_product_ids` (csv, default: '2934')
   - `ufsc_auto_create_user` (bool, default: false)
   - `ufsc_require_login_shortcodes` (bool, default: true)

--- a/Plugin_UFSC_GESTION_CLUB_13072025.php
+++ b/Plugin_UFSC_GESTION_CLUB_13072025.php
@@ -1129,7 +1129,7 @@ function ufsc_gestion_club_activate()
 
     // Set default WooCommerce product IDs
     if (!get_option('ufsc_affiliation_product_id')) {
-        add_option('ufsc_affiliation_product_id', 2933);
+        add_option('ufsc_affiliation_product_id', 4823);
     }
     if (!get_option('ufsc_licence_product_id')) {
         add_option('ufsc_licence_product_id', 2934);

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Pour l'achat de licences et affiliations en ligne :
 
 #### Configuration des produits
 1. **Créez les produits WooCommerce** :
-   - Produit "Affiliation Club UFSC" - ID recommandé : 2933
+   - Produit "Affiliation Club UFSC" - ID recommandé : 4823
    - Produit "Licence UFSC" - ID recommandé : 2934
 
 2. **Configuration via les réglages** :
@@ -168,14 +168,14 @@ Pour l'achat de licences et affiliations en ligne :
    ```php
    // Dans wp-config.php ou functions.php de votre thème
    add_action('init', function() {
-       update_option('ufsc_wc_affiliation_product_id', 2933);
+       update_option('ufsc_wc_affiliation_product_id', 4823);
        update_option('ufsc_wc_license_product_ids', '2934');
    });
    ```
 
 #### Mapping des produits WooCommerce
 Le plugin détecte automatiquement les achats via :
-- **ID Affiliation** : `ufsc_wc_affiliation_product_id` (fallback: 2933)
+- **ID Affiliation** : `ufsc_wc_affiliation_product_id` (fallback: 4823)
 - **ID Licence(s)** : `ufsc_wc_license_product_ids` (fallback: 2934)
 
 Les options peuvent être configurées via :
@@ -471,7 +471,7 @@ $upload_dir = wp_upload_dir();
 
 ### Version 1.2.0 (Janvier 2025)
 - ✅ **Page de réglages graphique** : Interface moderne pour lier les pages clés (espace club, licences, affiliation, attestations) et les produits WooCommerce
-- ✅ **Sélection graphique des IDs produits** : Choix visuel des produits WooCommerce (Affiliation ID 2933, Licence ID 2934)
+- ✅ **Sélection graphique des IDs produits** : Choix visuel des produits WooCommerce (Affiliation ID 4823, Licence ID 2934)
 - ✅ **Workflow de licences amélioré** : Processus brouillon > paiement WooCommerce > validation admin
 - ✅ **Design harmonisé** : Accessibilité, responsive et sécurité accrue sur l'administration et le front-end
 - ✅ **Gestion des documents via médiathèque** : Intégration native WordPress pour les documents clubs

--- a/WOOCOMMERCE_ECOMMERCE_DOCUMENTATION.md
+++ b/WOOCOMMERCE_ECOMMERCE_DOCUMENTATION.md
@@ -63,7 +63,7 @@ Accessibles via `Réglages > UFSC > Intégration WooCommerce`:
 
 ### Réglages existants conservés
 
-- **ID Produit Affiliation** (`ufsc_wc_affiliation_product_id`): 2933
+- **ID Produit Affiliation** (`ufsc_wc_affiliation_product_id`): 4823
 - **IDs Produits Licences** (`ufsc_wc_license_product_ids`): 2934
 
 ## Structure des prix

--- a/includes/admin/class-menu.php
+++ b/includes/admin/class-menu.php
@@ -2278,7 +2278,7 @@ class UFSC_Menu
         // Register WooCommerce product ID settings
         register_setting('ufsc_settings', 'ufsc_affiliation_product_id', array(
             'sanitize_callback' => 'absint',
-            'default' => 2933
+            'default' => 4823
         ));
         register_setting('ufsc_settings', 'ufsc_licence_product_id', array(
             'sanitize_callback' => 'absint',
@@ -4207,12 +4207,12 @@ class UFSC_Menu
      */
     public function affiliation_product_id_callback()
     {
-        $product_id = get_option('ufsc_affiliation_product_id', 2933);
+        $product_id = get_option('ufsc_affiliation_product_id', 4823);
         ?>
         <input type="number" id="ufsc_affiliation_product_id" name="ufsc_affiliation_product_id" 
                value="<?php echo esc_attr($product_id); ?>" min="1" step="1" />
         <p class="description">
-            <?php esc_html_e('ID du produit WooCommerce pour les affiliations de club (par défaut: 2933).', 'plugin-ufsc-gestion-club-13072025'); ?>
+            <?php esc_html_e('ID du produit WooCommerce pour les affiliations de club (par défaut: 4823).', 'plugin-ufsc-gestion-club-13072025'); ?>
             <?php if ($product_id) { ?>
                 <?php 
                 if (function_exists('wc_get_product')) {

--- a/includes/admin/class-ufsc-admin-settings.php
+++ b/includes/admin/class-ufsc-admin-settings.php
@@ -55,7 +55,7 @@ class UFSC_Admin_Settings {
             'ufsc_wc_affiliation_product_id',
             array(
                 'type' => 'integer',
-                'default' => 2933,
+                'default' => 4823,
                 'sanitize_callback' => 'absint'
             )
         );
@@ -320,7 +320,7 @@ class UFSC_Admin_Settings {
      * Render affiliation product ID field
      */
     public function render_affiliation_product_id_field() {
-        $value = $this->get_int_option('ufsc_wc_affiliation_product_id', 2933);
+        $value = $this->get_int_option('ufsc_wc_affiliation_product_id', 4823);
         ?>
         <input type="number" 
                id="ufsc_wc_affiliation_product_id" 
@@ -329,7 +329,7 @@ class UFSC_Admin_Settings {
                min="1" 
                class="regular-text" />
         <p class="description">
-            <?php _e('ID du produit WooCommerce utilisé pour les affiliations de club (défaut: 2933).', 'plugin-ufsc-gestion-club-13072025'); ?>
+            <?php _e('ID du produit WooCommerce utilisé pour les affiliations de club (défaut: 4823).', 'plugin-ufsc-gestion-club-13072025'); ?>
         </p>
         <?php
     }

--- a/includes/class-ufsc-woocommerce-integration.php
+++ b/includes/class-ufsc-woocommerce-integration.php
@@ -64,7 +64,7 @@ class UFSC_WooCommerce_Integration {
      */
     private function init() {
         // Get product IDs from options with fallback to constants
-        $this->affiliation_product_id = get_option('ufsc_wc_affiliation_product_id', 2933);
+        $this->affiliation_product_id = get_option('ufsc_wc_affiliation_product_id', 4823);
         $license_product_ids = get_option('ufsc_wc_license_product_ids', '2934');
         
         // Support comma-separated list of license product IDs

--- a/includes/tests/admin-settings-test.php
+++ b/includes/tests/admin-settings-test.php
@@ -26,7 +26,7 @@ function test_ufsc_admin_settings() {
     
     // Test 2: Test default option values
     $affiliation_id = (int) get_option('ufsc_wc_affiliation_product_id', 0);
-    if ($affiliation_id === 2933) {
+    if ($affiliation_id === 4823) {
         $results['default_affiliation'] = 'PASS - Default affiliation product ID is correct';
     } else {
         $results['default_affiliation'] = 'FAIL - Default affiliation product ID incorrect: ' . var_export($affiliation_id, true);

--- a/includes/woocommerce/auto-pack-affiliation.php
+++ b/includes/woocommerce/auto-pack-affiliation.php
@@ -57,7 +57,7 @@ class UFSC_Auto_Pack_Affiliation {
      * @return int
      */
     private function get_affiliation_product_id() {
-        return get_option('ufsc_wc_affiliation_product_id', 2933);
+        return get_option('ufsc_wc_affiliation_product_id', 4823);
     }
     
     /**

--- a/readme.txt
+++ b/readme.txt
@@ -50,7 +50,7 @@ Gestion complète des documents, licences, affiliations et expérience utilisate
 
 **Formulaires d'affiliation et création**
 * `[ufsc_formulaire_affiliation]` - Formulaire d'affiliation club avec intégration WooCommerce et upload de documents
-  - Redirige automatiquement vers le produit WooCommerce d'affiliation (ID 2933)
+  - Redirige automatiquement vers le produit WooCommerce d'affiliation (ID 4823)
   - Ajoute les métadonnées du club au panier (nom, ID, type de produit)
   - Traite automatiquement les commandes terminées pour mettre à jour le statut du club
 * `[ufsc_affiliation_club_form]` - Formulaire d'affiliation club avec upload des 6 documents obligatoires
@@ -83,7 +83,7 @@ Le plugin UFSC Gestion Club s'intègre avec WooCommerce pour gérer les achats d
 = IDs de produits requis =
 
 **Produit d'affiliation UFSC**
-* ID requis : `2933`
+* ID requis : `4823`
 * Constante : `UFSC_AFFILIATION_PRODUCT_ID`
 * Option alternative : `ufsc_affiliation_product_id`
 * Utilisation : Pack d'affiliation club (1 an + 10 licences incluses)
@@ -97,7 +97,7 @@ Le plugin UFSC Gestion Club s'intègre avec WooCommerce pour gérer les achats d
 
 **Méthode 1 : Création directe des produits**
 1. Aller dans `WooCommerce > Produits > Ajouter`
-2. Créer le produit d'affiliation avec l'ID 2933 :
+2. Créer le produit d'affiliation avec l'ID 4823 :
    - Titre : "Pack Affiliation Club UFSC"
    - Description : "Affiliation du club pour 1 an + 10 licences incluses"
    - Type : Produit simple
@@ -113,13 +113,13 @@ Si vous devez modifier les IDs de produits existants :
 
 ```sql
 -- Modifier l'ID d'un produit existant pour l'affiliation
-UPDATE wp_posts SET ID = 2933 WHERE post_type = 'product' AND post_title = 'Votre Produit Affiliation';
+UPDATE wp_posts SET ID = 4823 WHERE post_type = 'product' AND post_title = 'Votre Produit Affiliation';
 
 -- Modifier l'ID d'un produit existant pour les licences  
 UPDATE wp_posts SET ID = 2934 WHERE post_type = 'product' AND post_title = 'Votre Produit Licence';
 
 -- Mettre à jour les métadonnées associées
-UPDATE wp_postmeta SET post_id = 2933 WHERE post_id = 'ancien_id_affiliation';
+UPDATE wp_postmeta SET post_id = 4823 WHERE post_id = 'ancien_id_affiliation';
 UPDATE wp_postmeta SET post_id = 2934 WHERE post_id = 'ancien_id_licence';
 ```
 
@@ -127,7 +127,7 @@ UPDATE wp_postmeta SET post_id = 2934 WHERE post_id = 'ancien_id_licence';
 Vous pouvez définir l'ID du produit d'affiliation via une option WordPress :
 ```php
 // Dans votre functions.php ou via un plugin
-update_option('ufsc_affiliation_product_id', 2933);
+update_option('ufsc_affiliation_product_id', 4823);
 ```
 
 = Test de la configuration =
@@ -135,7 +135,7 @@ update_option('ufsc_affiliation_product_id', 2933);
 **Vérifier les liens d'achat d'affiliation**
 1. Accéder à une page contenant le shortcode `[ufsc_formulaire_affiliation]`
 2. Remplir le formulaire d'affiliation
-3. Vérifier que le bouton d'achat redirige vers `/produit/pack-affiliation-club-ufsc/` (ou l'URL de votre produit ID 2933)
+3. Vérifier que le bouton d'achat redirige vers `/produit/pack-affiliation-club-ufsc/` (ou l'URL de votre produit ID 4823)
 4. Vérifier que le produit se trouve bien dans le panier avec les métadonnées du club
 
 **Vérifier les liens d'achat de licence**
@@ -152,7 +152,7 @@ update_option('ufsc_affiliation_product_id', 2933);
 = Dépannage =
 
 **Erreur : Produit non trouvé**
-- Vérifier que les produits avec les IDs 2933 et 2934 existent dans WooCommerce
+- Vérifier que les produits avec les IDs 4823 et 2934 existent dans WooCommerce
 - Vérifier que les produits sont publiés et non en brouillon
 
 **Les boutons ne redirigent pas correctement**
@@ -194,7 +194,7 @@ Ce guide détaille comment créer et configurer les pages WordPress pour offrir 
 * Shortcode : `[ufsc_formulaire_affiliation]`
 * Description : Formulaire complet d'affiliation avec upload de documents et intégration WooCommerce
 * Accès : Utilisateurs connectés sans club existant
-* Comportement : Après soumission, redirige automatiquement vers le panier WooCommerce avec le produit d'affiliation (ID 2933)
+* Comportement : Après soumission, redirige automatiquement vers le panier WooCommerce avec le produit d'affiliation (ID 4823)
 
 **Page de création de club**
 * Nom suggéré : "Créer un Club"
@@ -281,12 +281,12 @@ Rendez-vous dans la section "UFSC Clubs" de votre administration WordPress et su
 
 = Comment configurer WooCommerce pour le plugin ? =
 
-Le plugin nécessite deux produits WooCommerce spécifiques avec les IDs 2933 (affiliation) et 2934 (licences). Consultez la section "Configuration WooCommerce" pour les instructions détaillées de configuration et de test.
+Le plugin nécessite deux produits WooCommerce spécifiques avec les IDs 4823 (affiliation) et 2934 (licences). Consultez la section "Configuration WooCommerce" pour les instructions détaillées de configuration et de test.
 
 = Les achats ne fonctionnent pas, que faire ? =
 
 Vérifiez que :
-1. Les produits WooCommerce avec les IDs 2933 et 2934 existent et sont publiés
+1. Les produits WooCommerce avec les IDs 4823 et 2934 existent et sont publiés
 2. Les permaliens sont à jour (Réglages > Permaliens > Enregistrer)
 3. WooCommerce est correctement configuré avec les pages panier et commande
 

--- a/tests/phpunit/test-ufsc-wc-handler.php
+++ b/tests/phpunit/test-ufsc-wc-handler.php
@@ -102,9 +102,9 @@ class Test_UFSC_WC_Handler extends WP_UnitTestCase
     public function test_woocommerce_product_configuration()
     {
         // Test affiliation product ID setting
-        update_option('ufsc_wc_affiliation_product_id', 2933);
+        update_option('ufsc_wc_affiliation_product_id', 4823);
         $affiliation_id = get_option('ufsc_wc_affiliation_product_id');
-        $this->assertEquals(2933, $affiliation_id);
+        $this->assertEquals(4823, $affiliation_id);
 
         // Test license product IDs setting (CSV)
         update_option('ufsc_wc_license_product_ids', '2934,2935,2936');


### PR DESCRIPTION
## Summary
- replace affiliation default ID 2933 with 4823 across plugin code
- update docs and tests to reference new WooCommerce product ID 4823

## Testing
- `phpunit --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ae21d75574832ba1afbf30e7274ed3