### PR TITLE
feat: add delegated license actions

### DIFF
--- a/assets/js/ufsc-licenses-direct.js
+++ b/assets/js/ufsc-licenses-direct.js
@@ -61,6 +61,61 @@
 
   [q,st,cat,qt,pp].forEach(el=> el && el.addEventListener('input', render));
 
+  tbody.addEventListener('click', function(e){
+    const btn = e.target.closest('button[data-a]');
+    if(!btn) return;
+    e.preventDefault();
+    const id = btn.getAttribute('data-id');
+    const act = btn.getAttribute('data-a');
+    if(!id) return;
+
+    if(act==='view'){
+      window.location.href = '?view_licence='+id;
+      return;
+    }
+    if(act==='edit'){
+      window.location.href = '?edit_licence='+id;
+      return;
+    }
+
+    if(act==='cart'){
+      window.location.href = '?ufsc_pay_licence='+id;
+      return;
+    }
+
+    if(act==='toggleq' || act==='delete'){
+      btn.disabled = true;
+      const params = new URLSearchParams();
+      params.append('action', act==='toggleq'?'ufscx_toggle_quota':'ufscx_delete_draft');
+      params.append('nonce', UFSCX_AJAX.nonce);
+      params.append('id', id);
+      fetch(UFSCX_AJAX.ajax, {
+        method: 'POST',
+        headers: {'Content-Type':'application/x-www-form-urlencoded'},
+        body: params
+      }).then(r=>r.json()).then(res=>{
+        if(res && res.success){
+          if(act==='toggleq'){
+            const row = data.find(r=>String(r.id)===String(id));
+            if(row){
+              row.quota = res.data && res.data.is_included ? 'Oui':'Non';
+            }
+          } else if(act==='delete'){
+            const idx = data.findIndex(r=>String(r.id)===String(id));
+            if(idx>-1){ data.splice(idx,1); }
+          }
+          render();
+        } else {
+          alert((res && res.data && res.data.message) || 'Erreur');
+        }
+      }).catch(()=>{
+        alert('Erreur');
+      }).finally(()=>{
+        btn.disabled = false;
+      });
+    }
+  });
+
   if(exportBtn){
     exportBtn.addEventListener('click',()=>{
       const headers = ['id','nom','prenom','email','sexe','date_naissance','ville','categorie','quota','statut','date_licence'];


### PR DESCRIPTION
## Summary
- handle licence table actions through delegated clicks
- support AJAX quota toggle, draft deletion, and redirects

## Testing
- `phpunit --version` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae274de798832b823486b05ced86ad