### PR TITLE
feat: add grid wrappers to frontend templates

### DIFF
--- a/assets/css/ufsc-theme.css
+++ b/assets/css/ufsc-theme.css
@@ -23,6 +23,18 @@
   line-height: 1.6;
 }
 
+.ufsc-grid {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 1024px) {
+  .ufsc-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
 .ufsc-card {
   background: #fff;
   border-radius: 8px;

--- a/includes/frontend/forms/affiliation-form-render.php
+++ b/includes/frontend/forms/affiliation-form-render.php
@@ -35,8 +35,11 @@ function ufsc_render_affiliation_form($args = [])
     
     // Check if user is logged in
     if (!is_user_logged_in()) {
-        return '<div class="ufsc-alert ufsc-alert-error">\n            <h4>Connexion requise</h4>\n            <p>Vous devez être connecté pour procéder à une affiliation.</p>' .
-            ufsc_render_login_prompt() . '\n            </div>';
+        return '<div class="ufsc-container"><div class="ufsc-grid"><div class="ufsc-card">'
+            . '<div class="ufsc-alert ufsc-alert-error">'
+            . '<h4>Connexion requise</h4><p>Vous devez être connecté pour procéder à une affiliation.</p>'
+            . ufsc_render_login_prompt()
+            . '</div></div></div></div>';
     }
     
     // Check if user already has a club
@@ -48,11 +51,11 @@ function ufsc_render_affiliation_form($args = [])
         
         // If club is already active, show info message
         if (ufsc_is_club_active($existing_club)) {
-            return '<div class="ufsc-alert ufsc-alert-info">
-                <h4>Club déjà affilié</h4>
-                <p>Votre club "' . esc_html($existing_club->nom) . '" est déjà affilié et actif.</p>
-                <p>Si vous souhaitez renouveler votre affiliation ou mettre à jour vos informations, contactez l\'administration UFSC.</p>
-                </div>';
+            return '<div class="ufsc-container"><div class="ufsc-grid"><div class="ufsc-card"><div class="ufsc-alert ufsc-alert-info">'
+                . '<h4>Club déjà affilié</h4>'
+                . '<p>Votre club "' . esc_html($existing_club->nom) . '" est déjà affilié et actif.</p>'
+                . '<p>Si vous souhaitez renouveler votre affiliation ou mettre à jour vos informations, contactez l\'administration UFSC.</p>'
+                . '</div></div></div></div>';
         }
     }
     
@@ -61,11 +64,11 @@ function ufsc_render_affiliation_form($args = [])
         $product_url = get_permalink(wc_get_product(ufsc_get_affiliation_product_id()));
         if ($product_url) {
             $action_text = $is_renewal ? 'Renouveler l\'affiliation' : 'Procéder à l\'affiliation';
-            return '<div class="ufsc-alert ufsc-alert-info">
-                <h4>' . ($is_renewal ? 'Renouvellement d\'affiliation' : 'Affiliation club') . '</h4>
-                <p>Pour ' . ($is_renewal ? 'renouveler votre affiliation' : 'affilier votre club') . ', veuillez utiliser notre système de commande intégré.</p>
-                <p><a href="' . esc_url($product_url) . '" class="ufsc-btn ufsc-btn-primary">' . esc_html($action_text) . '</a></p>
-                </div>';
+            return '<div class="ufsc-container"><div class="ufsc-grid"><div class="ufsc-card"><div class="ufsc-alert ufsc-alert-info">'
+                . '<h4>' . ($is_renewal ? 'Renouvellement d\'affiliation' : 'Affiliation club') . '</h4>'
+                . '<p>Pour ' . ($is_renewal ? 'renouveler votre affiliation' : 'affilier votre club') . ', veuillez utiliser notre système de commande intégré.</p>'
+                . '<p><a href="' . esc_url($product_url) . '" class="ufsc-btn ufsc-btn-primary">' . esc_html($action_text) . '</a></p>'
+                . '</div></div></div></div>';
         }
     }
     
@@ -73,11 +76,11 @@ function ufsc_render_affiliation_form($args = [])
     if (function_exists('WC') && WC()->cart) {
         foreach (WC()->cart->get_cart() as $cart_item) {
             if (isset($cart_item['product_id']) && $cart_item['product_id'] == ufsc_get_affiliation_product_id()) {
-                return '<div class="ufsc-alert ufsc-alert-warning">
-                    <h4>Affiliation en cours</h4>
-                    <p>Une demande d\'affiliation est déjà dans votre panier.</p>
-                    <p><a href="' . wc_get_cart_url() . '" class="ufsc-btn">Voir le panier</a></p>
-                    </div>';
+                return '<div class="ufsc-container"><div class="ufsc-grid"><div class="ufsc-card"><div class="ufsc-alert ufsc-alert-warning">'
+                    . '<h4>Affiliation en cours</h4>'
+                    . '<p>Une demande d\'affiliation est déjà dans votre panier.</p>'
+                    . '<p><a href="' . wc_get_cart_url() . '" class="ufsc-btn">Voir le panier</a></p>'
+                    . '</div></div></div></div>';
             }
         }
     }
@@ -90,7 +93,7 @@ function ufsc_render_affiliation_form($args = [])
     $nonce = wp_create_nonce('ufsc_affiliation_nonce');
     
     // Start form output
-    $output = '';
+    $output = '<div class="ufsc-container"><div class="ufsc-grid"><div class="ufsc-card">';
     
     if ($args['show_title']) {
         $title = $is_renewal ? 'Renouvellement d\'affiliation' : 'Affiliation de club';
@@ -232,7 +235,8 @@ function ufsc_render_affiliation_form($args = [])
     </div>';
     
     $output .= '</form>';
-    
+    $output .= '</div></div></div>';
+
     // Add JavaScript for form handling
     $output .= '<script>
     jQuery(document).ready(function($) {

--- a/includes/frontend/forms/licence-form-render.php
+++ b/includes/frontend/forms/licence-form-render.php
@@ -16,10 +16,13 @@ function ufsc_render_licence_form($args = array()){
     if (empty($args['club'])){
         if (function_exists('ufsc_check_frontend_access')){
             $access = ufsc_check_frontend_access('licence');
-            if (!$access['allowed']) return $access['error_message'];
+            if (!$access['allowed']) {
+                return '<div class="ufsc-container"><div class="ufsc-grid"><div class="ufsc-card">'
+                    . $access['error_message'] . '</div></div></div>';
+            }
             $club = $access['club'];
         } else {
-            return '<div class="ufsc-error">Accès refusé.</div>';
+            return '<div class="ufsc-container"><div class="ufsc-grid"><div class="ufsc-card"><div class="ufsc-error">Accès refusé.</div></div></div></div>';
         }
     } else {
         $club = $args['club'];
@@ -40,6 +43,9 @@ function ufsc_render_licence_form($args = array()){
 
     ob_start();
     ?>
+    <div class="ufsc-container">
+    <div class="ufsc-grid">
+    <div class="ufsc-card">
     <?php if (!empty($args['show_title'])): ?>
       <h3>Nouvelle licence sportive</h3>
     <?php endif; ?>
@@ -180,6 +186,9 @@ function ufsc_render_licence_form($args = array()){
         <button type="submit" class="ufsc-btn"><?php echo esc_html($args['submit_button_text']); ?></button>
       </div>
     </form>
+    </div>
+    </div>
+    </div>
 
     <script>
     (function($){

--- a/includes/frontend/shortcodes/affiliation-form-shortcode.php
+++ b/includes/frontend/shortcodes/affiliation-form-shortcode.php
@@ -15,10 +15,10 @@ function ufsc_formulaire_affiliation_shortcode($atts)
 {
     // Si l'utilisateur n'est pas connecté, afficher formulaire de connexion
     if (!is_user_logged_in()) {
-        return '<div class="ufsc-alert ufsc-alert-error">
-                <p>Vous devez être connecté pour accéder au formulaire d\'affiliation.</p>' .
-                ufsc_render_login_prompt() .
-                '</div>';
+        return '<div class="ufsc-container"><div class="ufsc-grid"><div class="ufsc-card"><div class="ufsc-alert ufsc-alert-error">'
+            . '<p>Vous devez être connecté pour accéder au formulaire d\'affiliation.</p>'
+            . ufsc_render_login_prompt()
+            . '</div></div></div></div>';
     }
 
     // Vérifier si l'utilisateur a déjà un club affilié
@@ -26,30 +26,34 @@ function ufsc_formulaire_affiliation_shortcode($atts)
     
     // Vérifier que la fonction existe pour éviter les erreurs fatales
     if (!function_exists('ufsc_get_user_club')) {
-        return '<div class="ufsc-alert ufsc-alert-error">
-                <p>Erreur de configuration du plugin. Veuillez contacter l\'administrateur.</p>
-                </div>';
+        return '<div class="ufsc-container"><div class="ufsc-grid"><div class="ufsc-card"><div class="ufsc-alert ufsc-alert-error">'
+                . '<p>Erreur de configuration du plugin. Veuillez contacter l\'administrateur.</p>'
+                . '</div></div></div></div>';
     }
     
     $club = ufsc_get_user_club($user_id);
 
     if ($club && $club->statut !== 'Refusé') {
         $dashboard_button = ufsc_generate_safe_navigation_button('dashboard', 'Accéder à mon espace club', 'ufsc-btn ufsc-btn-primary', true);
-        return '<div class="ufsc-alert ufsc-alert-info">
-                <h4>✅ Vous avez déjà un club</h4>
-                <p>Vous avez déjà un club en cours d\'affiliation ou affilié.</p>
-                <p>' . $dashboard_button . '</p>
-                </div>';
+        return '<div class="ufsc-container"><div class="ufsc-grid"><div class="ufsc-card"><div class="ufsc-alert ufsc-alert-info">'
+                . '<h4>✅ Vous avez déjà un club</h4>'
+                . '<p>Vous avez déjà un club en cours d\'affiliation ou affilié.</p>'
+                . '<p>' . $dashboard_button . '</p>'
+                . '</div></div></div></div>';
     }
 
     // Démarrer la capture de sortie
     ob_start();
+
+    echo '<div class="ufsc-container"><div class="ufsc-grid"><div class="ufsc-card">';
 
     // Inclusion du formulaire club avec paramètre spécial pour affiliation
     require_once UFSC_PLUGIN_PATH . 'includes/clubs/form-club.php';
 
     // Appel de la fonction avec le paramètre affiliation=true
     ufsc_render_club_form(($club ? $club->id : 0), true, true);
+
+    echo '</div></div></div>';
 
     // Récupérer le contenu capturé
     return ob_get_clean();

--- a/includes/frontend/shortcodes/ajouter-licencie-shortcode.php
+++ b/includes/frontend/shortcodes/ajouter-licencie-shortcode.php
@@ -22,14 +22,16 @@ function ufsc_ajouter_licencie_shortcode($atts)
     $access_check = ufsc_check_frontend_access('licence');
     
     if (!$access_check['allowed']) {
-        return $access_check['error_message'];
+        return '<div class="ufsc-container"><div class="ufsc-grid"><div class="ufsc-card">'
+            . $access_check['error_message'] . '</div></div></div>';
     }
     
     $club = $access_check['club'];
 
     // CORRECTION: Use standardized status checking
     if (!ufsc_is_club_active($club)) {
-        return ufsc_render_club_status_alert($club, 'licence');
+        return '<div class="ufsc-container"><div class="ufsc-grid"><div class="ufsc-card">'
+            . ufsc_render_club_status_alert($club, 'licence') . '</div></div></div>';
     }
 
     // Enqueue AJAX script and styles
@@ -46,17 +48,18 @@ function ufsc_render_ajax_licensee_form($club)
     ob_start();
     ?>
     <div class="ufsc-container">
-        <h2 class="ufsc-section-title">Ajouter un licencié</h2>
-        
-        <!-- Quota information -->
-        <?php echo ufsc_render_quota_information($club); ?>
-        
-        <div class="ufsc-card">
-            <div class="ufsc-card-header">
-                <h3>Informations du licencié</h3>
-                <p>Les informations saisies seront ajoutées au panier pour finaliser l'achat de la licence.</p>
+        <div class="ufsc-grid">
+            <div class="ufsc-card">
+                <h2 class="ufsc-section-title">Ajouter un licencié</h2>
+                <?php echo ufsc_render_quota_information($club); ?>
             </div>
-            <div class="ufsc-card-body">
+
+            <div class="ufsc-card">
+                <div class="ufsc-card-header">
+                    <h3>Informations du licencié</h3>
+                    <p>Les informations saisies seront ajoutées au panier pour finaliser l'achat de la licence.</p>
+                </div>
+                <div class="ufsc-card-body">
                 <form id="ufsc-add-licencie-form" class="ufsc-form">
                     
                     <div class="ufsc-form-row ufsc-form-group">
@@ -131,6 +134,7 @@ function ufsc_render_ajax_licensee_form($club)
                         </p>
                     </div>
                 </form>
+                </div>
             </div>
         </div>
     </div>

--- a/includes/frontend/shortcodes/club-form-shortcode.php
+++ b/includes/frontend/shortcodes/club-form-shortcode.php
@@ -20,20 +20,26 @@ function ufsc_formulaire_club_shortcode($atts)
         }
 
         // Rediriger vers la même page après connexion/inscription
-        return ufsc_login_register_shortcode([
-            'redirect'      => get_permalink(),
-            'show_register' => 'yes',
-        ]);
+        return '<div class="ufsc-container"><div class="ufsc-grid"><div class="ufsc-card">' .
+            ufsc_login_register_shortcode([
+                'redirect'      => get_permalink(),
+                'show_register' => 'yes',
+            ]) .
+            '</div></div></div>';
     }
 
     // Démarrer la capture de sortie
     ob_start();
+
+    echo '<div class="ufsc-container"><div class="ufsc-grid"><div class="ufsc-card">';
 
     // Inclusion du formulaire
     require_once UFSC_PLUGIN_PATH . 'includes/clubs/form-club.php';
 
     // Appel de la fonction avec les paramètres frontend=true et affiliation=true
     ufsc_render_club_form(0, true, true);
+
+    echo '</div></div></div>';
 
     // Récupérer le contenu capturé
     return ob_get_clean();

--- a/includes/frontend/shortcodes/club-menu-shortcode.php
+++ b/includes/frontend/shortcodes/club-menu-shortcode.php
@@ -64,11 +64,12 @@ function ufsc_club_menu_shortcode($atts = array()) {
     
     // Generate menu HTML
     $output = ufsc_render_club_menu($menu_pages);
-    
+
     // Enqueue CSS only once
     ufsc_enqueue_club_menu_css();
-    
-    return $output;
+
+    return '<div class="ufsc-container"><div class="ufsc-grid"><div class="ufsc-card">'
+        . $output . '</div></div></div>';
 }
 
 /**

--- a/includes/frontend/shortcodes/licence-button-shortcode.php
+++ b/includes/frontend/shortcodes/licence-button-shortcode.php
@@ -17,14 +17,16 @@ function ufsc_bouton_licence_shortcode($atts)
     $access_check = ufsc_check_frontend_access('licence');
     
     if (!$access_check['allowed']) {
-        return $access_check['error_message'];
+        return '<div class="ufsc-container"><div class="ufsc-grid"><div class="ufsc-card">'
+            . $access_check['error_message'] . '</div></div></div>';
     }
     
     $club = $access_check['club'];
 
     // CORRECTION: Use standardized status checking 
     if (!ufsc_is_club_active($club)) {
-        return ufsc_render_club_status_alert($club, 'licence');
+        return '<div class="ufsc-container"><div class="ufsc-grid"><div class="ufsc-card">'
+            . ufsc_render_club_status_alert($club, 'licence') . '</div></div></div>';
     }
 
     // Récupérer le nombre de licences
@@ -42,7 +44,7 @@ function ufsc_bouton_licence_shortcode($atts)
     $product_url = get_permalink(ufsc_get_licence_product_id());
 
     // Générer le bouton avec informations de quota
-    $output = '<div class="ufsc-licence-button-container">';
+    $output = '<div class="ufsc-container"><div class="ufsc-grid"><div class="ufsc-card ufsc-licence-button-container">';
 
     // Show quota status only if not unlimited
     if (!$is_unlimited_quota) {
@@ -75,7 +77,7 @@ function ufsc_bouton_licence_shortcode($atts)
                     </div>';
     }
 
-    $output .= '</div>';
+    $output .= '</div></div></div>';
 
     return $output;
 }

--- a/includes/frontend/shortcodes/licenses-direct.php
+++ b/includes/frontend/shortcodes/licenses-direct.php
@@ -30,11 +30,11 @@ function ufscx_resolve_club_id($user_id = 0){
 if (!function_exists('ufscx_licences_direct_shortcode')) {
 function ufscx_licences_direct_shortcode($atts){
     if (!is_user_logged_in()){
-        return '<div class="ufsc-alert ufsc-alert-error">Vous devez être connecté.</div>';
+        return '<div class="ufsc-container"><div class="ufsc-grid"><div class="ufsc-card"><div class="ufsc-alert ufsc-alert-error">Vous devez être connecté.</div></div></div></div>';
     }
     $club_id = ufscx_resolve_club_id();
     if (!$club_id){
-        return '<div class="ufsc-alert ufsc-alert-error">Club introuvable pour ce compte.</div>';
+        return '<div class="ufsc-container"><div class="ufsc-grid"><div class="ufsc-card"><div class="ufsc-alert ufsc-alert-error">Club introuvable pour ce compte.</div></div></div></div>';
     }
     global $wpdb;
     $club_name = $wpdb->get_var(
@@ -68,7 +68,7 @@ function ufscx_licences_direct_shortcode($atts){
     }
 
     ob_start(); ?>
-    <div class="ufscx-licences">
+    <div class="ufsc-container"><div class="ufsc-grid"><div class="ufsc-card ufscx-licences">
       <div class="ufscx-header">
         <a class="ufscx-btn ufscx-btn-primary" href="<?php echo esc_url($a['add_url']); ?>">+ Ajouter un licencié</a>
         <?php if ($a['enable_csv']==='yes'): ?>
@@ -123,7 +123,7 @@ function ufscx_licences_direct_shortcode($atts){
       </table>
 
       <script type="application/json" id="ufscx-data"><?php echo wp_json_encode($licences); ?></script>
-    </div>
+    </div></div></div>
     <?php
     return ob_get_clean();
 }

--- a/includes/frontend/shortcodes/login-register-shortcode.php
+++ b/includes/frontend/shortcodes/login-register-shortcode.php
@@ -30,7 +30,8 @@ function ufsc_login_register_shortcode($atts = array()) {
     
     // If user is already logged in, show message and dashboard link
     if (is_user_logged_in()) {
-        return ufsc_render_logged_in_message();
+        return '<div class="ufsc-container"><div class="ufsc-grid">'
+            . ufsc_render_logged_in_message() . '</div></div>';
     }
     
     // Handle registration form submission
@@ -47,7 +48,7 @@ function ufsc_login_register_shortcode($atts = array()) {
         // If there are errors, they will be displayed in the form
     }
     
-    $output = '<div class="ufsc-login-register-wrapper">';
+    $output = '<div class="ufsc-container"><div class="ufsc-grid"><div class="ufsc-login-register-wrapper">';
     
     // Add any error messages
     if (isset($registration_result) && !$registration_result['success']) {
@@ -109,7 +110,7 @@ function ufsc_render_logged_in_message() {
     $output .= __('Se déconnecter', 'plugin-ufsc-gestion-club-13072025');
     $output .= '</a>';
 
-    $output .= '</div>';
+    $output .= '</div></div></div>';
 
     return $output;
 }

--- a/includes/frontend/shortcodes/order-history.php
+++ b/includes/frontend/shortcodes/order-history.php
@@ -37,10 +37,11 @@ function ufsc_order_history_shortcode($atts = array()) {
         }
 
         if (empty($orders)) {
-            return '<p>' . esc_html__("Aucune commande trouvée.", 'plugin-ufsc-gestion-club-13072025') . '</p>';
+            return '<div class="ufsc-container"><div class="ufsc-grid"><div class="ufsc-card"><p>'
+                . esc_html__("Aucune commande trouvée.", 'plugin-ufsc-gestion-club-13072025') . '</p></div></div></div>';
         }
 
-        $output  = '<table class="ufsc-order-history">';
+        $output  = '<div class="ufsc-container"><div class="ufsc-grid"><div class="ufsc-card"><table class="ufsc-order-history">';
         $output .= '<thead><tr>';
         $output .= '<th>' . esc_html__("Commande", 'plugin-ufsc-gestion-club-13072025') . '</th>';
         $output .= '<th>' . esc_html__("Date", 'plugin-ufsc-gestion-club-13072025') . '</th>';
@@ -65,7 +66,7 @@ function ufsc_order_history_shortcode($atts = array()) {
             $output .= '</tr>';
         }
 
-        $output .= '</tbody></table>';
+        $output .= '</tbody></table></div></div></div>';
 
         return $output;
     }, $atts);

--- a/includes/frontend/shortcodes/recent-licences-shortcode.php
+++ b/includes/frontend/shortcodes/recent-licences-shortcode.php
@@ -46,14 +46,15 @@ function ufsc_recent_licences_shortcode($atts = array()) {
     // Get club manager instance
     $club_manager = UFSC_Club_Manager::get_instance();
     if (!$club_manager) {
-        return '<div class="ufsc-alert ufsc-alert-error"><p>' . __('Erreur : impossible de charger les données.', 'plugin-ufsc-gestion-club-13072025') . '</p></div>';
+        return '<div class="ufsc-container"><div class="ufsc-grid"><div class="ufsc-card"><div class="ufsc-alert ufsc-alert-error"><p>'
+            . __('Erreur : impossible de charger les données.', 'plugin-ufsc-gestion-club-13072025') . '</p></div></div></div></div>';
     }
     
     // Get licences for the club
     $licences = $club_manager->get_licences_by_club($club->id);
     
     if (empty($licences)) {
-        return ufsc_render_no_licences_message();
+        return '<div class="ufsc-container"><div class="ufsc-grid">' . ufsc_render_no_licences_message() . '</div></div>';
     }
     
     // Sort licences by creation date (most recent first)
@@ -70,7 +71,8 @@ function ufsc_recent_licences_shortcode($atts = array()) {
     }
     
     // Render the widget
-    return ufsc_render_recent_licences_widget($licences, $atts);
+    return '<div class="ufsc-container"><div class="ufsc-grid">'
+        . ufsc_render_recent_licences_widget($licences, $atts) . '</div></div>';
 }
 
 /**

--- a/includes/shortcodes-front.php
+++ b/includes/shortcodes-front.php
@@ -206,7 +206,7 @@ function ufsc_render_login_requirement($context = '') {
         $extra_message = '<p>' . esc_html__('Veuillez vous connecter pour créer votre club.', 'plugin-ufsc-gestion-club-13072025') . '</p>';
     }
 
-    return '<div class="ufsc-login-required">'
+    return '<div class="ufsc-container"><div class="ufsc-grid"><div class="ufsc-card ufsc-login-required">'
         . '<div class="ufsc-alert ufsc-alert-info">'
             . '<h4>' . esc_html__('Connexion requise', 'plugin-ufsc-gestion-club-13072025') . '</h4>'
             . '<p>' . esc_html__('Vous devez être connecté pour accéder à cette section.', 'plugin-ufsc-gestion-club-13072025') . '</p>'
@@ -214,7 +214,7 @@ function ufsc_render_login_requirement($context = '') {
             . ufsc_render_login_prompt()
         . '</div>'
         . '<input type="hidden" name="ufsc_nonce" value="' . esc_attr($nonce) . '">'
-        . '</div>';
+        . '</div></div></div>';
 }
 
 /**
@@ -225,24 +225,24 @@ function ufsc_render_login_requirement($context = '') {
  */
 function ufsc_render_no_club_message($context = '') {
     $nonce = wp_create_nonce('ufsc_frontend_action');
-    
-    $message = '<div class="ufsc-no-club">
+
+    $message = '<div class="ufsc-container"><div class="ufsc-grid"><div class="ufsc-card ufsc-no-club">
         <div class="ufsc-alert ufsc-alert-warning">
             <h4>' . esc_html__('Aucun club associé', 'plugin-ufsc-gestion-club-13072025') . '</h4>
             <p>' . esc_html__('Vous n\'êtes pas encore associé à un club.', 'plugin-ufsc-gestion-club-13072025') . '</p>';
-    
+
     if ($context === 'dashboard') {
         $register_url = ufsc_get_page_url('club_form') ?: '#';
         $message .= '<div class="ufsc-button-group">
-                <a href="' . esc_url($register_url) . '" class="ufsc-btn ufsc-btn-primary">' . 
+                <a href="' . esc_url($register_url) . '" class="ufsc-btn ufsc-btn-primary">' .
                     esc_html__('Créer un club', 'plugin-ufsc-gestion-club-13072025') . '</a>
             </div>';
     }
-    
+
     $message .= '</div>
         <input type="hidden" name="ufsc_nonce" value="' . esc_attr($nonce) . '">
-    </div>';
-    
+    </div></div></div>';
+
     return $message;
 }
 
@@ -257,6 +257,7 @@ function ufsc_render_simple_club_register_form($atts) {
     
     ob_start();
     ?>
+    <div class="ufsc-container"><div class="ufsc-grid">
     <div class="ufsc-club-register-form">
         <div class="ufsc-card">
             <div class="ufsc-card-header">
@@ -308,6 +309,7 @@ function ufsc_render_simple_club_register_form($atts) {
             </div>
         </div>
     </div>
+    </div></div>
     <?php
     return ob_get_clean();
 }
@@ -515,12 +517,17 @@ function ufsc_render_club_account_form($club, $atts) {
         }
     }
     </style>
+    <div class="ufsc-container"><div class="ufsc-grid">
     <div class="ufsc-club-account">
-        
+
         <?php if ($updated): ?>
-        <div class="ufsc-alert ufsc-alert-success">
-            <p><strong><?php esc_html_e('Succès !', 'plugin-ufsc-gestion-club-13072025'); ?></strong> 
-               <?php esc_html_e('Les informations du club ont été mises à jour.', 'plugin-ufsc-gestion-club-13072025'); ?></p>
+        <div class="ufsc-card">
+            <div class="ufsc-card-body">
+                <div class="ufsc-alert ufsc-alert-success">
+                    <p><strong><?php esc_html_e('Succès !', 'plugin-ufsc-gestion-club-13072025'); ?></strong>
+                       <?php esc_html_e('Les informations du club ont été mises à jour.', 'plugin-ufsc-gestion-club-13072025'); ?></p>
+                </div>
+            </div>
         </div>
         <?php endif; ?>
 
@@ -768,6 +775,7 @@ function ufsc_render_club_account_form($club, $atts) {
 
         <input type="hidden" name="ufsc_nonce" value="<?php echo esc_attr($nonce); ?>">
     </div>
+    </div></div>
     <?php
     return ob_get_clean();
 }


### PR DESCRIPTION
## Summary
- wrap frontend shortcodes and forms in ufsc-container/ufsc-grid structure
- add ufsc-card wrappers around logical blocks
- define responsive ufsc-grid styles

## Testing
- `php -l includes/frontend/forms/licence-form-render.php`
- `php -l includes/frontend/forms/affiliation-form-render.php`
- `php -l includes/frontend/shortcodes/affiliation-form-shortcode.php`
- `php -l includes/frontend/shortcodes/ajouter-licencie-shortcode.php`
- `php -l includes/frontend/shortcodes/club-form-shortcode.php`
- `php -l includes/frontend/shortcodes/club-menu-shortcode.php`
- `php -l includes/frontend/shortcodes/licence-button-shortcode.php`
- `php -l includes/frontend/shortcodes/licenses-direct.php`
- `php -l includes/frontend/shortcodes/login-register-shortcode.php`
- `php -l includes/frontend/shortcodes/order-history.php`
- `php -l includes/frontend/shortcodes/recent-licences-shortcode.php`
- `php -l includes/shortcodes-front.php`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ae3758487c832bb81085c3a97c03ee