### PR TITLE
refactor: unify front-end form layout

### DIFF
--- a/assets/css/form-licence.css
+++ b/assets/css/form-licence.css
@@ -37,23 +37,15 @@
 /* Form grid layout */
 .ufsc-form-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    grid-template-columns: 1fr;
     gap: 20px;
     margin-bottom: 0;
 }
 
-.ufsc-form-grid-2 {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 20px;
-    margin-bottom: 0;
-}
-
-.ufsc-form-grid-3 {
-    display: grid;
-    grid-template-columns: 1fr 1fr 1fr;
-    gap: 20px;
-    margin-bottom: 0;
+@media (min-width: 1024px) {
+    .ufsc-form-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
 }
 
 /* Form fields */
@@ -149,16 +141,19 @@
 }
 
 /* Error states */
-.ufsc-form-field.error input,
-.ufsc-form-field.error select,
-.ufsc-form-field.error textarea {
+/* États d'erreur basés sur aria-invalid */
+.ufsc-form-field [aria-invalid="true"] {
     border-color: #dc3232;
 }
 
-.ufsc-form-field .error-message {
+.ufsc-form-error {
     color: #dc3232;
     font-size: 12px;
     margin-top: 5px;
+    display: none;
+}
+
+.ufsc-form-field [aria-invalid="true"] ~ .ufsc-form-error {
     display: block;
 }
 
@@ -204,8 +199,6 @@
         padding: 20px 15px;
     }
     
-    .ufsc-form-grid-2,
-    .ufsc-form-grid-3,
     .ufsc-mobile-stack {
         grid-template-columns: 1fr;
     }

--- a/assets/css/ufsc-theme.css
+++ b/assets/css/ufsc-theme.css
@@ -234,6 +234,35 @@
   }
 }
 
+/* Nouvelle grille de champs : 1 colonne mobile, 2 colonnes >=1024px */
+.ufsc-form-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 20px;
+}
+
+@media (min-width: 1024px) {
+  .ufsc-form-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+/* Messages d'aide et d'erreur */
+.ufsc-form-error {
+  color: var(--ufsc-red);
+  font-size: 12px;
+  margin-top: 5px;
+  display: none;
+}
+
+.ufsc-form-field [aria-invalid="true"] {
+  border-color: var(--ufsc-red);
+}
+
+.ufsc-form-field [aria-invalid="true"] ~ .ufsc-form-error {
+  display: block;
+}
+
 .ufsc-form label {
   font-weight: 600;
   color: var(--ufsc-text);

--- a/includes/frontend/forms/affiliation-form-render.php
+++ b/includes/frontend/forms/affiliation-form-render.php
@@ -118,28 +118,38 @@ function ufsc_render_affiliation_form($args = [])
         <div class="ufsc-form-field">
             <label for="nom">Nom du club *</label>
             <input type="text" id="nom" name="nom" required maxlength="200" value="' . ($existing_club ? esc_attr($existing_club->nom) : '') . '">
+            <p class="ufsc-form-hint"></p>
+            <span class="ufsc-form-error"></span>
         </div>
         
         <div class="ufsc-form-field">
             <label for="description">Description du club</label>
             <textarea id="description" name="description" rows="4" maxlength="1000">' . ($existing_club ? esc_textarea($existing_club->description) : '') . '</textarea>
+            <p class="ufsc-form-hint"></p>
+            <span class="ufsc-form-error"></span>
         </div>
         
-        <div class="ufsc-form-row">
+        <div class="ufsc-form-grid">
             <div class="ufsc-form-field">
                 <label for="adresse">Adresse *</label>
                 <input type="text" id="adresse" name="adresse" required maxlength="200" value="' . ($existing_club ? esc_attr($existing_club->adresse) : '') . '">
+                <p class="ufsc-form-hint"></p>
+                <span class="ufsc-form-error"></span>
             </div>
         </div>
         
-        <div class="ufsc-form-row">
+        <div class="ufsc-form-grid">
             <div class="ufsc-form-field">
                 <label for="code_postal">Code postal *</label>
                 <input type="text" id="code_postal" name="code_postal" required pattern="[0-9]{5}" maxlength="5" value="' . ($existing_club ? esc_attr($existing_club->code_postal) : '') . '">
+                <p class="ufsc-form-hint"></p>
+                <span class="ufsc-form-error"></span>
             </div>
             <div class="ufsc-form-field">
                 <label for="ville">Ville *</label>
                 <input type="text" id="ville" name="ville" required maxlength="100" value="' . ($existing_club ? esc_attr($existing_club->ville) : '') . '">
+                <p class="ufsc-form-hint"></p>
+                <span class="ufsc-form-error"></span>
             </div>
         </div>';
     
@@ -157,6 +167,8 @@ function ufsc_render_affiliation_form($args = [])
         }
         
         $output .= '</select>
+            <p class="ufsc-form-hint"></p>
+            <span class="ufsc-form-error"></span>
         </div>';
     }
     
@@ -165,59 +177,69 @@ function ufsc_render_affiliation_form($args = [])
     // Contact information section
     $output .= '<div class="ufsc-form-section">
         <h4>Contact</h4>
-        <div class="ufsc-form-row">
+        <div class="ufsc-form-grid">
             <div class="ufsc-form-field">
                 <label for="email">Email *</label>
                 <input type="email" id="email" name="email" required maxlength="150" value="' . ($existing_club ? esc_attr($existing_club->email) : '') . '">
+                <p class="ufsc-form-hint"></p>
+                <span class="ufsc-form-error"></span>
             </div>
             <div class="ufsc-form-field">
                 <label for="telephone">Téléphone</label>
                 <input type="tel" id="telephone" name="telephone" maxlength="20" value="' . ($existing_club ? esc_attr($existing_club->telephone) : '') . '">
+                <p class="ufsc-form-hint"></p>
+                <span class="ufsc-form-error"></span>
             </div>
         </div>
         
         <div class="ufsc-form-field">
             <label for="site_web">Site web</label>
             <input type="url" id="site_web" name="site_web" maxlength="200" placeholder="https://" value="' . ($existing_club ? esc_attr($existing_club->site_web) : '') . '">
+            <p class="ufsc-form-hint"></p>
+            <span class="ufsc-form-error"></span>
         </div>
     </div>';
     
     // Additional information section
     $output .= '<div class="ufsc-form-section">
         <h4>Informations complémentaires</h4>
-        <div class="ufsc-form-row">
+        <div class="ufsc-form-grid">
             <div class="ufsc-form-field">
                 <label for="siret">SIRET</label>
                 <input type="text" id="siret" name="siret" maxlength="14" pattern="[0-9]{14}" value="' . ($existing_club ? esc_attr($existing_club->siret) : '') . '">
+                <p class="ufsc-form-hint"></p>
+                <span class="ufsc-form-error"></span>
             </div>
             <div class="ufsc-form-field">
                 <label for="num_rna">Numéro RNA</label>
                 <input type="text" id="num_rna" name="num_rna" maxlength="10" value="' . ($existing_club ? esc_attr($existing_club->num_rna) : '') . '">
+                <p class="ufsc-form-hint"></p>
+                <span class="ufsc-form-error"></span>
             </div>
         </div>
         
         <div class="ufsc-form-field">
             <label for="activites">Activités pratiquées</label>
             <textarea id="activites" name="activites" rows="3" maxlength="500" placeholder="Décrivez les activités sportives proposées par votre club...">' . ($existing_club ? esc_textarea($existing_club->activites) : '') . '</textarea>
+            <p class="ufsc-form-hint"></p>
+            <span class="ufsc-form-error"></span>
         </div>
     </div>';
     
     // Terms and conditions
     $output .= '<div class="ufsc-form-section">
         <div class="ufsc-form-field">
-            <label class="ufsc-checkbox-label">
-                <input type="checkbox" id="accept_terms" name="accept_terms" required>
-                <span class="ufsc-checkbox-custom"></span>
-                J\'accepte les <a href="#" target="_blank">conditions générales</a> et le <a href="#" target="_blank">règlement intérieur</a> de l\'UFSC *
-            </label>
+            <label for="accept_terms">J\'accepte les <a href="#" target="_blank">conditions générales</a> et le <a href="#" target="_blank">règlement intérieur</a> de l\'UFSC *</label>
+            <input type="checkbox" id="accept_terms" name="accept_terms" required>
+            <p class="ufsc-form-hint"></p>
+            <span class="ufsc-form-error"></span>
         </div>
-        
+
         <div class="ufsc-form-field">
-            <label class="ufsc-checkbox-label">
-                <input type="checkbox" id="accept_data" name="accept_data" required>
-                <span class="ufsc-checkbox-custom"></span>
-                J\'accepte le traitement de mes données personnelles conformément à la <a href="#" target="_blank">politique de confidentialité</a> *
-            </label>
+            <label for="accept_data">J\'accepte le traitement de mes données personnelles conformément à la <a href="#" target="_blank">politique de confidentialité</a> *</label>
+            <input type="checkbox" id="accept_data" name="accept_data" required>
+            <p class="ufsc-form-hint"></p>
+            <span class="ufsc-form-error"></span>
         </div>
     </div>';
     

--- a/includes/frontend/forms/licence-form-render.php
+++ b/includes/frontend/forms/licence-form-render.php
@@ -47,8 +47,8 @@ function ufsc_render_licence_form($args = array()){
     <form id="<?php echo esc_attr($args['form_id']); ?>" class="ufsc-licence-form ufsc-licence-form ufsc-form" method="post" action="<?php echo esc_url( get_permalink() ); ?>">
       <?php wp_nonce_field('ufsc_add_licence_nonce', 'ufsc_nonce'); ?>
       <?php wp_nonce_field('ufsc_add_licence_to_cart', '_ufsc_licence_nonce'); ?>
-      <input type="hidden" name="action" value="ufsc_submit_licence">
-      <input type="hidden" name="club_id" value="<?php echo esc_attr($club->id); ?>">
+        <input type="hidden" name="action" value="ufsc_submit_licence">
+        <input type="hidden" name="club_id" value="<?php echo esc_attr($club->id); ?>">
       <input type="hidden" name="context" value="<?php echo esc_attr($args['context']); ?>">
       <?php if (!empty($prefill['id'])): ?>
         <input type="hidden" name="licence_id" value="<?php echo esc_attr($prefill['id']); ?>">
@@ -56,21 +56,27 @@ function ufsc_render_licence_form($args = array()){
 
       <div class="ufsc-form-section">
         <h4>Informations personnelles</h4>
-        <div class="ufsc-form-row">
+        <div class="ufsc-form-grid">
           <div class="ufsc-form-field">
             <label for="nom">Nom *</label>
             <input type="text" id="nom" name="nom" required maxlength="100" value="<?php echo $v('nom'); ?>">
+            <p class="ufsc-form-hint"></p>
+            <span class="ufsc-form-error"></span>
           </div>
           <div class="ufsc-form-field">
             <label for="prenom">Prénom *</label>
             <input type="text" id="prenom" name="prenom" required maxlength="100" value="<?php echo $v('prenom'); ?>">
+            <p class="ufsc-form-hint"></p>
+            <span class="ufsc-form-error"></span>
           </div>
         </div>
 
-        <div class="ufsc-form-row">
+        <div class="ufsc-form-grid">
           <div class="ufsc-form-field">
             <label for="date_naissance">Date de naissance *</label>
             <input type="date" id="date_naissance" name="date_naissance" required value="<?php echo $v('date_naissance'); ?>">
+            <p class="ufsc-form-hint"></p>
+            <span class="ufsc-form-error"></span>
           </div>
           <div class="ufsc-form-field">
             <label for="sexe">Sexe *</label>
@@ -79,12 +85,16 @@ function ufsc_render_licence_form($args = array()){
               <option value="M"<?php echo $sel('sexe','M'); ?>>Masculin</option>
               <option value="F"<?php echo $sel('sexe','F'); ?>>Féminin</option>
             </select>
+            <p class="ufsc-form-hint"></p>
+            <span class="ufsc-form-error"></span>
           </div>
         </div>
 
         <div class="ufsc-form-field">
           <label for="email">Email *</label>
           <input type="email" id="email" name="email" required maxlength="150" value="<?php echo $v('email'); ?>">
+          <p class="ufsc-form-hint"></p>
+          <span class="ufsc-form-error"></span>
         </div>
       </div>
 
@@ -93,36 +103,48 @@ function ufsc_render_licence_form($args = array()){
         <div class="ufsc-form-field">
           <label for="adresse">Adresse</label>
           <input type="text" id="adresse" name="adresse" maxlength="200" value="<?php echo $v('adresse'); ?>">
+          <p class="ufsc-form-hint"></p>
+          <span class="ufsc-form-error"></span>
         </div>
-        <div class="ufsc-form-row">
+        <div class="ufsc-form-grid">
           <div class="ufsc-form-field">
             <label for="suite_adresse">Complément d'adresse</label>
             <input type="text" id="suite_adresse" name="suite_adresse" maxlength="200" value="<?php echo $v('suite_adresse'); ?>">
+            <p class="ufsc-form-hint"></p>
+            <span class="ufsc-form-error"></span>
           </div>
           <div class="ufsc-form-field">
             <label for="code_postal">Code postal</label>
             <input type="text" id="code_postal" name="code_postal" maxlength="10" value="<?php echo $v('code_postal'); ?>">
+            <p class="ufsc-form-hint"></p>
+            <span class="ufsc-form-error"></span>
           </div>
         </div>
         <div class="ufsc-form-field">
           <label for="ville">Ville</label>
           <input type="text" id="ville" name="ville" maxlength="120" value="<?php echo $v('ville'); ?>">
+          <p class="ufsc-form-hint"></p>
+          <span class="ufsc-form-error"></span>
         </div>
-        <div class="ufsc-form-row">
+        <div class="ufsc-form-grid">
           <div class="ufsc-form-field">
             <label for="tel_mobile">Téléphone</label>
             <input type="text" id="tel_mobile" name="tel_mobile" maxlength="25" value="<?php echo $v('tel_mobile'); ?>">
+            <p class="ufsc-form-hint"></p>
+            <span class="ufsc-form-error"></span>
           </div>
           <div class="ufsc-form-field">
             <label for="profession">Profession</label>
             <input type="text" id="profession" name="profession" maxlength="100" value="<?php echo $v('profession'); ?>">
+            <p class="ufsc-form-hint"></p>
+            <span class="ufsc-form-error"></span>
           </div>
         </div>
       </div>
 
       <div class="ufsc-form-section">
         <h4>Rôle & type</h4>
-        <div class="ufsc-form-row">
+        <div class="ufsc-form-grid">
           <div class="ufsc-form-field">
             <label for="fonction">Fonction</label>
             <select id="fonction" name="fonction">
@@ -133,45 +155,98 @@ function ufsc_render_licence_form($args = array()){
               <option value="entraineur"<?php echo $sel('fonction','entraineur'); ?>>Entraîneur</option>
               <option value="adherent"<?php echo $sel('fonction','adherent'); ?>>Adhérent</option>
             </select>
+            <p class="ufsc-form-hint"></p>
+            <span class="ufsc-form-error"></span>
           </div>
           <div class="ufsc-form-field">
-            <label><input type="checkbox" name="competition" value="1"<?php echo $is_checked('competition'); ?>> Compétition</label>
+            <label for="competition">Compétition</label>
+            <input type="checkbox" id="competition" name="competition" value="1"<?php echo $is_checked('competition'); ?>>
+            <p class="ufsc-form-hint"></p>
+            <span class="ufsc-form-error"></span>
           </div>
         </div>
-        <div class="ufsc-form-row">
+        <div class="ufsc-form-grid">
           <div class="ufsc-form-field">
-            <label><input type="checkbox" id="licence_delegataire" name="licence_delegataire" value="1"<?php echo $is_checked('licence_delegataire'); ?>> Licence délégataire</label>
+            <label for="licence_delegataire">Licence délégataire</label>
+            <input type="checkbox" id="licence_delegataire" name="licence_delegataire" value="1"<?php echo $is_checked('licence_delegataire'); ?>>
+            <p class="ufsc-form-hint"></p>
+            <span class="ufsc-form-error"></span>
           </div>
           <div class="ufsc-form-field" id="numero_licence_delegataire_field" style="display:none;">
             <label for="numero_licence_delegataire">N° délégataire</label>
             <input type="text" id="numero_licence_delegataire" name="numero_licence_delegataire" value="<?php echo $v('numero_licence_delegataire'); ?>">
+            <p class="ufsc-form-hint"></p>
+            <span class="ufsc-form-error"></span>
           </div>
-        </div>
+      </div>
       </div>
 
       <div class="ufsc-form-section">
         <h4>Autorisations et communications</h4>
-        <div class="ufsc-form-grid-2">
-          <label><input type="checkbox" name="diffusion_image" value="1"<?php echo $is_checked('diffusion_image'); ?>> Consentement diffusion image</label>
-          <label><input type="checkbox" name="infos_fsasptt" value="1"<?php echo $is_checked('infos_fsasptt'); ?>> Recevoir les infos FSASPTT</label>
-          <label><input type="checkbox" name="infos_asptt" value="1"<?php echo $is_checked('infos_asptt'); ?>> Recevoir les infos ASPTT</label>
-          <label><input type="checkbox" name="infos_cr" value="1"<?php echo $is_checked('infos_cr'); ?>> Recevoir les infos Comité Régional</label>
-          <label><input type="checkbox" name="infos_partenaires" value="1"<?php echo $is_checked('infos_partenaires'); ?>> Recevoir les infos partenaires</label>
+        <div class="ufsc-form-grid">
+          <div class="ufsc-form-field">
+            <label for="diffusion_image">Consentement diffusion image</label>
+            <input type="checkbox" id="diffusion_image" name="diffusion_image" value="1"<?php echo $is_checked('diffusion_image'); ?>>
+            <p class="ufsc-form-hint"></p>
+            <span class="ufsc-form-error"></span>
+          </div>
+          <div class="ufsc-form-field">
+            <label for="infos_fsasptt">Recevoir les infos FSASPTT</label>
+            <input type="checkbox" id="infos_fsasptt" name="infos_fsasptt" value="1"<?php echo $is_checked('infos_fsasptt'); ?>>
+            <p class="ufsc-form-hint"></p>
+            <span class="ufsc-form-error"></span>
+          </div>
+          <div class="ufsc-form-field">
+            <label for="infos_asptt">Recevoir les infos ASPTT</label>
+            <input type="checkbox" id="infos_asptt" name="infos_asptt" value="1"<?php echo $is_checked('infos_asptt'); ?>>
+            <p class="ufsc-form-hint"></p>
+            <span class="ufsc-form-error"></span>
+          </div>
+          <div class="ufsc-form-field">
+            <label for="infos_cr">Recevoir les infos Comité Régional</label>
+            <input type="checkbox" id="infos_cr" name="infos_cr" value="1"<?php echo $is_checked('infos_cr'); ?>>
+            <p class="ufsc-form-hint"></p>
+            <span class="ufsc-form-error"></span>
+          </div>
+          <div class="ufsc-form-field">
+            <label for="infos_partenaires">Recevoir les infos partenaires</label>
+            <input type="checkbox" id="infos_partenaires" name="infos_partenaires" value="1"<?php echo $is_checked('infos_partenaires'); ?>>
+            <p class="ufsc-form-hint"></p>
+            <span class="ufsc-form-error"></span>
+          </div>
         </div>
       </div>
 
       <div class="ufsc-form-section">
         <h4>Déclarations et assurances</h4>
-        <div class="ufsc-form-grid-2">
-          <label><input type="checkbox" name="honorabilite" value="1"<?php echo $is_checked('honorabilite'); ?>> Déclaration d'honorabilité</label>
-          <label><input type="checkbox" name="assurance_dommage_corporel" value="1"<?php echo $is_checked('assurance_dommage_corporel'); ?>> Assurance dommage corporel</label>
-          <label><input type="checkbox" name="assurance_assistance" value="1"<?php echo $is_checked('assurance_assistance'); ?>> Assurance assistance</label>
+        <div class="ufsc-form-grid">
+          <div class="ufsc-form-field">
+            <label for="honorabilite">Déclaration d'honorabilité</label>
+            <input type="checkbox" id="honorabilite" name="honorabilite" value="1"<?php echo $is_checked('honorabilite'); ?>>
+            <p class="ufsc-form-hint"></p>
+            <span class="ufsc-form-error"></span>
+          </div>
+          <div class="ufsc-form-field">
+            <label for="assurance_dommage_corporel">Assurance dommage corporel</label>
+            <input type="checkbox" id="assurance_dommage_corporel" name="assurance_dommage_corporel" value="1"<?php echo $is_checked('assurance_dommage_corporel'); ?>>
+            <p class="ufsc-form-hint"></p>
+            <span class="ufsc-form-error"></span>
+          </div>
+          <div class="ufsc-form-field">
+            <label for="assurance_assistance">Assurance assistance</label>
+            <input type="checkbox" id="assurance_assistance" name="assurance_assistance" value="1"<?php echo $is_checked('assurance_assistance'); ?>>
+            <p class="ufsc-form-hint"></p>
+            <span class="ufsc-form-error"></span>
+          </div>
         </div>
       </div>
 
       <div class="ufsc-form-section">
         <div class="ufsc-form-field">
-          <label><input type="checkbox" name="ufsc_rules_ack" value="1" required> J'ai pris connaissance des règlements — <a href="https://ufsc-france.fr/ufsc-reglements-sportifs-techniques-interieur/" target="_blank" rel="noopener">Lire les règlements</a></label>
+          <label for="ufsc_rules_ack">J'ai pris connaissance des règlements — <a href="https://ufsc-france.fr/ufsc-reglements-sportifs-techniques-interieur/" target="_blank" rel="noopener">Lire les règlements</a></label>
+          <input type="checkbox" id="ufsc_rules_ack" name="ufsc_rules_ack" value="1" required>
+          <p class="ufsc-form-hint"></p>
+          <span class="ufsc-form-error"></span>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- switch front-end forms to `.ufsc-form-grid` containers with labels, hint and error blocks
- add responsive grid & error styles to UFSC theme and licence stylesheets
- ensure checkboxes and validation markers use accessible, aria-invalid-aware markup

## Testing
- `php -l includes/frontend/forms/licence-form-render.php`
- `php -l includes/frontend/forms/affiliation-form-render.php`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ae37626310832bb4a1cde21f60a966