### PR TITLE
Refactor frontend inline styles into utility classes

### DIFF
--- a/assets/css/ufsc-theme.css
+++ b/assets/css/ufsc-theme.css
@@ -357,8 +357,24 @@
   .ufsc-dashboard {
     grid-template-columns: 1fr;
   }
-  
+
   .ufsc-form {
     padding: 0 15px;
   }
 }
+
+/* ===== UTILITY CLASSES ===== */
+.ufsc-mb-20 { margin-bottom: 20px; }
+.ufsc-mb-15 { margin-bottom: 15px; }
+.ufsc-mt-20 { margin-top: 20px; }
+.ufsc-mt-30 { margin-top: 30px; }
+.ufsc-mt-8 { margin-top: 8px; }
+.ufsc-mt-10 { margin-top: 10px; }
+.ufsc-ml-10 { margin-left: 10px; }
+.ufsc-w-250 { width: 250px; }
+.ufsc-color-red { color: var(--ufsc-red); }
+.ufsc-color-gray { color: #999; }
+.ufsc-hidden { display: none; }
+.ufsc-inline { display: inline; }
+.ufsc-justify-end { justify-content: flex-end; }
+.ufsc-edit-contact { padding: 15px; background: #f9f9f9; border-radius: 5px; }

--- a/includes/frontend/club/attestations.php
+++ b/includes/frontend/club/attestations.php
@@ -60,7 +60,7 @@ function ufsc_render_official_attestations($club)
     $output .= '</div>';
     $output .= '<div class="ufsc-card-body">';
 
-    $output .= '<div class="ufsc-info-box" style="margin-bottom: 20px;">
+    $output .= '<div class="ufsc-info-box ufsc-mb-20">
                 <p>Ces documents sont transmis après validation par l\'administration UFSC.</p>
                 </div>';
 
@@ -165,7 +165,7 @@ function ufsc_render_licence_attestations($club)
     $output .= '</div>';
     $output .= '<div class="ufsc-card-body">';
 
-    $output .= '<div class="ufsc-info-box" style="margin-bottom: 20px;">
+    $output .= '<div class="ufsc-info-box ufsc-mb-20">
                 <p><strong>Note :</strong> Les attestations de licence sont ajoutées en back-office par l\'administration pour chaque licence validée.</p>
                 </div>';
 

--- a/includes/frontend/club/club-infos.php
+++ b/includes/frontend/club/club-infos.php
@@ -324,7 +324,7 @@ function ufsc_handle_contact_update($club)
  */
 function ufsc_render_contact_edit_form($club)
 {
-    $output = '<div id="ufsc-edit-contact-form" style="display:none; margin-top:20px; padding:15px; background:#f9f9f9; border-radius:5px;">';
+    $output = '<div id="ufsc-edit-contact-form" class="ufsc-edit-contact ufsc-hidden ufsc-mt-20">';
     $output .= '<h4>Modifier mes coordonnées</h4>';
     $output .= '<form method="post" class="ufsc-inline-form">';
     $output .= wp_nonce_field('ufsc_update_contact', 'ufsc_contact_nonce', true, false);
@@ -333,19 +333,19 @@ function ufsc_render_contact_edit_form($club)
     $output .= '<input type="hidden" id="ufsc-edit-field-name" name="field_name" value="">';
 
     // Email field
-    $output .= '<div id="ufsc-edit-email-field" style="display:none">';
+    $output .= '<div id="ufsc-edit-email-field" class="ufsc-hidden">';
     $output .= '<label for="email">Adresse email:</label>';
     $output .= '<input type="email" name="email" id="email" value="' . esc_attr($club->email) . '" required>';
     $output .= '</div>';
 
     // Phone field
-    $output .= '<div id="ufsc-edit-telephone-field" style="display:none">';
+    $output .= '<div id="ufsc-edit-telephone-field" class="ufsc-hidden">';
     $output .= '<label for="telephone">Téléphone:</label>';
     $output .= '<input type="tel" name="telephone" id="telephone" value="' . esc_attr($club->telephone) . '">';
     $output .= '</div>';
 
     // Action buttons
-    $output .= '<div style="margin-top:10px;">';
+    $output .= '<div class="ufsc-mt-10">';
     $output .= '<button type="submit" class="ufsc-btn">Enregistrer</button>';
     $output .= '<button type="button" class="ufsc-btn ufsc-btn-outline" id="ufsc-cancel-edit">Annuler</button>';
     $output .= '</div>';
@@ -472,11 +472,11 @@ function ufsc_render_quota_section($club, $stats)
         $output .= '</div>';
 
         if ($stats['remaining'] <= 0) {
-            $output .= '<div class="ufsc-form-hint" style="color:var(--ufsc-red); margin-top:8px;">';
+        $output .= '<div class="ufsc-form-hint ufsc-color-red ufsc-mt-8">';
             $output .= 'Votre quota est épuisé. <a href="mailto:contact@ufsc-france.org?subject=Demande%20d%27augmentation%20de%20quota">Contactez l\'administration</a> pour l\'augmenter.';
             $output .= '</div>';
         } else {
-            $output .= '<div class="ufsc-form-hint" style="margin-top:8px;">';
+        $output .= '<div class="ufsc-form-hint ufsc-mt-8">';
             $output .= 'Licences incluses dans votre pack d\'affiliation. ';
             $output .= '<a href="' . esc_url(add_query_arg(['section' => 'licences', 'action' => 'new'], get_permalink())) . '">Ajouter une licence</a>';
             $output .= '</div>';

--- a/includes/frontend/club/notifications.php
+++ b/includes/frontend/club/notifications.php
@@ -78,7 +78,7 @@ function ufsc_render_notifications_summary($club)
         $output .= '<p>Vous avez <strong>' . $notifications_stats['unread_count'] . '</strong> notification' . ($notifications_stats['unread_count'] > 1 ? 's' : '') . ' non lue' . ($notifications_stats['unread_count'] > 1 ? 's' : '') . '.</p>';
         $output .= '</div>';
         $output .= '<div class="ufsc-summary-actions">';
-        $output .= '<form method="post" style="display: inline;">';
+        $output .= '<form method="post" class="ufsc-inline">';
         $output .= wp_nonce_field('ufsc_notifications_actions', 'ufsc_notifications_nonce', true, false);
         $output .= '<button type="submit" name="ufsc_mark_all_read" class="ufsc-btn ufsc-btn-outline">Tout marquer comme lu</button>';
         $output .= '</form>';
@@ -165,7 +165,7 @@ function ufsc_render_notifications_list($club)
             $output .= '<div class="ufsc-notification-actions">';
             
             if (!$notification['read']) {
-                $output .= '<form method="post" style="display: inline;">';
+                $output .= '<form method="post" class="ufsc-inline">';
                 $output .= wp_nonce_field('ufsc_notifications_actions', 'ufsc_notifications_nonce', true, false);
                 $output .= '<input type="hidden" name="notification_id" value="' . esc_attr($notification['id']) . '">';
                 $output .= '<button type="submit" name="ufsc_mark_read" class="ufsc-btn-sm" title="Marquer comme lu">';

--- a/includes/frontend/club/paiements.php
+++ b/includes/frontend/club/paiements.php
@@ -61,7 +61,7 @@ function ufsc_render_payment_status($club)
     $output .= '<div class="ufsc-card-body">';
 
     // Information about UFSC fees - according to requirements
-    $output .= '<div class="ufsc-info-box" style="margin-bottom: 20px;">
+    $output .= '<div class="ufsc-info-box ufsc-mb-20">
                 <h4>Tarifs UFSC</h4>
                 <p>• <strong>Cotisation d\'affiliation :</strong> 150€/an</p>
                 <p>• <strong>Licence individuelle :</strong> 35€</p>
@@ -340,7 +340,7 @@ function ufsc_render_invoice_management($club)
     // Banking information for transfers - Updated with correct UFSC details
     $output .= '<div class="ufsc-banking-info">';
     $output .= '<h4>Coordonnées bancaires pour virement</h4>';
-    $output .= '<div class="ufsc-info-box ufsc-info-box-important" style="margin-bottom: 15px;">';
+    $output .= '<div class="ufsc-info-box ufsc-info-box-important ufsc-mb-15">';
     $output .= '<h5>⚠️ Nouvelles coordonnées bancaires UFSC</h5>';
     $output .= '<p>Merci d\'utiliser exclusivement ces coordonnées pour vos virements à l\'UFSC.</p>';
     $output .= '</div>';

--- a/includes/frontend/forms/affiliation-form-render.php
+++ b/includes/frontend/forms/affiliation-form-render.php
@@ -226,7 +226,7 @@ function ufsc_render_affiliation_form($args = [])
         <button type="submit" class="ufsc-btn ufsc-btn-primary" id="ufsc-submit-affiliation">
             ' . esc_html($args['submit_button_text']) . '
         </button>
-        <div class="ufsc-form-loading" style="display:none;">
+        <div class="ufsc-form-loading ufsc-hidden">
             <span class="ufsc-spinner"></span> Traitement en cours...
         </div>
     </div>';

--- a/includes/frontend/forms/licence-form-render.php
+++ b/includes/frontend/forms/licence-form-render.php
@@ -142,7 +142,7 @@ function ufsc_render_licence_form($args = array()){
           <div class="ufsc-form-field">
             <label><input type="checkbox" id="licence_delegataire" name="licence_delegataire" value="1"<?php echo $is_checked('licence_delegataire'); ?>> Licence délégataire</label>
           </div>
-          <div class="ufsc-form-field" id="numero_licence_delegataire_field" style="display:none;">
+          <div class="ufsc-form-field ufsc-hidden" id="numero_licence_delegataire_field">
             <label for="numero_licence_delegataire">N° délégataire</label>
             <input type="text" id="numero_licence_delegataire" name="numero_licence_delegataire" value="<?php echo $v('numero_licence_delegataire'); ?>">
           </div>

--- a/includes/frontend/parts/licence-list.php
+++ b/includes/frontend/parts/licence-list.php
@@ -30,9 +30,9 @@ $licences = $wpdb->get_results($wpdb->prepare(
 ));
 ?>
 
-<form method="get" class="ufsc-search-form" style="margin-bottom: 20px;">
+<form method="get" class="ufsc-search-form ufsc-mb-20">
     <input type="hidden" name="page_id" value="<?php echo esc_attr(get_the_ID()); ?>">
-    <input type="text" name="search_licence" placeholder="🔍 Rechercher..." value="<?php echo esc_attr($search); ?>" style="width:250px;">
+    <input type="text" name="search_licence" placeholder="🔍 Rechercher..." value="<?php echo esc_attr($search); ?>" class="ufsc-w-250">
     <button type="submit" class="button button-primary">Filtrer</button>
 </form>
 
@@ -73,7 +73,7 @@ $licences = $wpdb->get_results($wpdb->prepare(
                                 📄 Télécharger
                             </a>
                         <?php else: ?>
-                            <span style="color: #999;">—</span>
+                            <span class="ufsc-color-gray">—</span>
                         <?php endif; ?>
                     </td>
                 </tr>


### PR DESCRIPTION
## Summary
- add utility CSS classes for margins, display helpers, and text colors
- replace several frontend inline styles with utility classes

## Testing
- `npm test` *(fails: Missing script "test")*
- `php -l includes/frontend/parts/licence-list.php`
- `php -l includes/frontend/forms/affiliation-form-render.php`
- `php -l includes/frontend/club/notifications.php`
- `php -l includes/frontend/forms/licence-form-render.php`
- `php -l includes/frontend/club/paiements.php`
- `php -l includes/frontend/club/attestations.php`
- `php -l includes/frontend/club/club-infos.php`


------
https://chatgpt.com/codex/tasks/task_e_68ae376a74c8832b97c12cab3561a535