### PR TITLE
Refactor licence form to vanilla JS and drop jQuery enqueues

### DIFF
--- a/assets/js/dashboard-search.js
+++ b/assets/js/dashboard-search.js
@@ -1,46 +1,50 @@
-jQuery(document).ready(function($) {
-    $('#ufsc-search').on('input', function() {
-        const query = $(this).val();
+document.addEventListener('DOMContentLoaded', () => {
+    const search = document.querySelector('#ufsc-search');
+    const results = document.querySelector('#ufsc-results');
+    if (search) {
+        search.addEventListener('input', async function() {
+            const query = this.value;
 
-        if (query.length < 2) {
-            $('#ufsc-results').html('');
-            return;
-        }
+            if (query.length < 2) {
+                if (results) results.innerHTML = '';
+                return;
+            }
 
-        $.ajax({
-            url: ufscAjax.ajax_url,
-            method: 'POST',
-            data: {
-                action: 'ufsc_search_dashboard',
-                query: query,
-                nonce: ufscAjax.nonce
-            },
-            success: function(response) {
-                if (response.success) {
+            try {
+                const response = await fetch(ufscAjax.ajax_url, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8' },
+                    body: new URLSearchParams({
+                        action: 'ufsc_search_dashboard',
+                        query: query,
+                        nonce: ufscAjax.nonce
+                    })
+                });
+                const data = await response.json();
+                if (data.success) {
                     let html = '<ul>';
-                    if (response.data.clubs.length > 0) {
+                    if (data.data.clubs.length > 0) {
                         html += '<li><strong>Clubs</strong><ul>';
-                        response.data.clubs.forEach(function(club) {
+                        data.data.clubs.forEach(club => {
                             html += '<li>🏛️ ' + club.nom + '</li>';
                         });
                         html += '</ul></li>';
                     }
-                    if (response.data.licences.length > 0) {
+                    if (data.data.licences.length > 0) {
                         html += '<li><strong>Licenciés</strong><ul>';
-                        response.data.licences.forEach(function(licence) {
+                        data.data.licences.forEach(licence => {
                             html += '<li>👤 ' + licence.prenom + ' ' + licence.nom + '</li>';
                         });
                         html += '</ul></li>';
                     }
                     html += '</ul>';
-                    $('#ufsc-results').html(html);
-                } else {
-                    $('#ufsc-results').html('<p>Aucun résultat trouvé.</p>');
+                    if (results) results.innerHTML = html;
+                } else if (results) {
+                    results.innerHTML = '<p>Aucun résultat trouvé.</p>';
                 }
-            },
-            error: function() {
-                $('#ufsc-results').html('<p>Erreur AJAX.</p>');
+            } catch (error) {
+                if (results) results.innerHTML = '<p>Erreur AJAX.</p>';
             }
         });
-    });
+    }
 });

--- a/assets/js/form-licence.js
+++ b/assets/js/form-licence.js
@@ -1,129 +1,181 @@
-jQuery(document).ready(function($) {
-    // Enhanced form interactions for UFSC License Form
-    
+document.addEventListener('DOMContentLoaded', function() {
     // Auto-toggle fields based on reduction selections
-    $('#reduction_postier').change(function() {
-        const $laposteField = $('#identifiant_laposte').closest('.ufsc-form-field');
-        if ($(this).is(':checked')) {
-            $laposteField.show().find('input').attr('required', true);
-        } else {
-            $laposteField.hide().find('input').attr('required', false);
-        }
-    }).trigger('change');
-    
-    // Auto-toggle delegataire license number field
-    $('#licence_delegataire').change(function() {
-        const $numeroField = $('#numero_licence_delegataire').closest('.ufsc-form-field');
-        if ($(this).is(':checked')) {
-            $numeroField.show().find('input').attr('required', true);
-        } else {
-            $numeroField.hide().find('input').attr('required', false);
-        }
-    }).trigger('change');
-    
-    // Form validation improvements
-    $('form').on('submit', function(e) {
-        let hasErrors = false;
-        
-        // Check required fields
-        $(this).find('input[required], select[required]').each(function() {
-            const $field = $(this);
-            const $container = $field.closest('.ufsc-form-field');
-            
-            if (!$field.val().trim()) {
-                $container.addClass('error');
-                if (!$container.find('.error-message').length) {
-                    $container.append('<span class="error-message">Ce champ est requis</span>');
+    const reductionPostier = document.querySelector('#reduction_postier');
+    if (reductionPostier) {
+        const laposteField = document.querySelector('#identifiant_laposte')?.closest('.ufsc-form-field');
+        const toggleLaposte = () => {
+            if (reductionPostier.checked) {
+                if (laposteField) {
+                    laposteField.style.display = '';
+                    const input = laposteField.querySelector('input');
+                    if (input) input.required = true;
                 }
-                hasErrors = true;
             } else {
-                $container.removeClass('error').find('.error-message').remove();
-            }
-        });
-        
-        // Email validation
-        $('input[type="email"]').each(function() {
-            const $field = $(this);
-            const $container = $field.closest('.ufsc-form-field');
-            const email = $field.val().trim();
-            
-            if (email && !isValidEmail(email)) {
-                $container.addClass('error');
-                if (!$container.find('.error-message').length) {
-                    $container.append('<span class="error-message">Format d\'email invalide</span>');
+                if (laposteField) {
+                    laposteField.style.display = 'none';
+                    const input = laposteField.querySelector('input');
+                    if (input) input.required = false;
                 }
-                hasErrors = true;
-            } else if (email) {
-                $container.removeClass('error').find('.error-message').remove();
             }
-        });
-        
-        // Phone validation (basic)
-        $('input[name="tel_fixe"], input[name="tel_mobile"]').each(function() {
-            const $field = $(this);
-            const $container = $field.closest('.ufsc-form-field');
-            const phone = $field.val().trim();
-            
-            if (phone && !isValidPhone(phone)) {
-                $container.addClass('error');
-                if (!$container.find('.error-message').length) {
-                    $container.append('<span class="error-message">Format de téléphone invalide</span>');
+        };
+        reductionPostier.addEventListener('change', toggleLaposte);
+        toggleLaposte();
+    }
+
+    // Auto-toggle delegataire license number field
+    const licenceDelegataire = document.querySelector('#licence_delegataire');
+    if (licenceDelegataire) {
+        const numeroField = document.querySelector('#numero_licence_delegataire')?.closest('.ufsc-form-field');
+        const toggleNumero = () => {
+            if (licenceDelegataire.checked) {
+                if (numeroField) {
+                    numeroField.style.display = '';
+                    const input = numeroField.querySelector('input');
+                    if (input) input.required = true;
                 }
-                hasErrors = true;
-            } else if (phone) {
-                $container.removeClass('error').find('.error-message').remove();
+            } else {
+                if (numeroField) {
+                    numeroField.style.display = 'none';
+                    const input = numeroField.querySelector('input');
+                    if (input) input.required = false;
+                }
+            }
+        };
+        licenceDelegataire.addEventListener('change', toggleNumero);
+        toggleNumero();
+    }
+
+    // Form validation improvements
+    document.querySelectorAll('form').forEach(form => {
+        form.addEventListener('submit', function(e) {
+            let hasErrors = false;
+
+            // Check required fields
+            form.querySelectorAll('input[required], select[required]').forEach(field => {
+                const container = field.closest('.ufsc-form-field');
+                if (!field.value.trim()) {
+                    container.classList.add('error');
+                    if (!container.querySelector('.error-message')) {
+                        const span = document.createElement('span');
+                        span.className = 'error-message';
+                        span.textContent = 'Ce champ est requis';
+                        container.appendChild(span);
+                    }
+                    hasErrors = true;
+                } else {
+                    container.classList.remove('error');
+                    const msg = container.querySelector('.error-message');
+                    if (msg) msg.remove();
+                }
+            });
+
+            // Email validation
+            form.querySelectorAll('input[type="email"]').forEach(field => {
+                const container = field.closest('.ufsc-form-field');
+                const email = field.value.trim();
+
+                if (email && !isValidEmail(email)) {
+                    container.classList.add('error');
+                    if (!container.querySelector('.error-message')) {
+                        const span = document.createElement('span');
+                        span.className = 'error-message';
+                        span.textContent = "Format d'email invalide";
+                        container.appendChild(span);
+                    }
+                    hasErrors = true;
+                } else if (email) {
+                    container.classList.remove('error');
+                    const msg = container.querySelector('.error-message');
+                    if (msg) msg.remove();
+                }
+            });
+
+            // Phone validation (basic)
+            form.querySelectorAll('input[name="tel_fixe"], input[name="tel_mobile"]').forEach(field => {
+                const container = field.closest('.ufsc-form-field');
+                const phone = field.value.trim();
+
+                if (phone && !isValidPhone(phone)) {
+                    container.classList.add('error');
+                    if (!container.querySelector('.error-message')) {
+                        const span = document.createElement('span');
+                        span.className = 'error-message';
+                        span.textContent = 'Format de téléphone invalide';
+                        container.appendChild(span);
+                    }
+                    hasErrors = true;
+                } else if (phone) {
+                    container.classList.remove('error');
+                    const msg = container.querySelector('.error-message');
+                    if (msg) msg.remove();
+                }
+            });
+
+            if (hasErrors) {
+                e.preventDefault();
+                const firstError = document.querySelector('.ufsc-form-field.error');
+                if (firstError) {
+                    const offset = firstError.getBoundingClientRect().top + window.pageYOffset - 100;
+                    window.scrollTo({ top: offset, behavior: 'smooth' });
+                }
             }
         });
-        
-        if (hasErrors) {
-            e.preventDefault();
-            $('html, body').animate({
-                scrollTop: $('.ufsc-form-field.error:first').offset().top - 100
-            }, 500);
-        }
     });
-    
+
     // Clear error states on input
-    $('input, select, textarea').on('input change', function() {
-        $(this).closest('.ufsc-form-field').removeClass('error').find('.error-message').remove();
+    const clearError = (e) => {
+        const container = e.target.closest('.ufsc-form-field');
+        if (container) {
+            container.classList.remove('error');
+            const msg = container.querySelector('.error-message');
+            if (msg) msg.remove();
+        }
+    };
+    document.querySelectorAll('input, select, textarea').forEach(el => {
+        el.addEventListener('input', clearError);
+        el.addEventListener('change', clearError);
     });
-    
+
     // Enhanced search filters
-    $('.ufsc-filters-form').on('submit', function() {
-        // Remove empty filter values to clean up URL
-        $(this).find('input, select').each(function() {
-            if (!$(this).val()) {
-                $(this).prop('disabled', true);
-            }
+    document.querySelectorAll('.ufsc-filters-form').forEach(form => {
+        form.addEventListener('submit', () => {
+            form.querySelectorAll('input, select').forEach(field => {
+                if (!field.value) {
+                    field.disabled = true;
+                }
+            });
         });
     });
-    
+
     // Auto-uppercase postal code
-    $('input[name="code_postal"]').on('input', function() {
-        $(this).val($(this).val().toUpperCase());
+    document.querySelectorAll('input[name="code_postal"]').forEach(input => {
+        input.addEventListener('input', () => {
+            input.value = input.value.toUpperCase();
+        });
     });
-    
+
     // Helper functions
     function isValidEmail(email) {
         const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
         return emailRegex.test(email);
     }
-    
+
     function isValidPhone(phone) {
         // French phone number validation (basic)
         const phoneRegex = /^(?:(?:\+33|0)[1-9](?:[.-\s]?\d{2}){4})$/;
         return phoneRegex.test(phone.replace(/[\s.-]/g, ''));
     }
-    
+
     // Responsive form enhancements
     function adjustFormLayout() {
-        if ($(window).width() < 768) {
-            $('.ufsc-form-grid-2, .ufsc-form-grid-3').addClass('ufsc-mobile-stack');
+        const grids = document.querySelectorAll('.ufsc-form-grid-2, .ufsc-form-grid-3');
+        if (window.innerWidth < 768) {
+            grids.forEach(g => g.classList.add('ufsc-mobile-stack'));
         } else {
-            $('.ufsc-form-grid-2, .ufsc-form-grid-3').removeClass('ufsc-mobile-stack');
+            grids.forEach(g => g.classList.remove('ufsc-mobile-stack'));
         }
     }
-    
-    $(window).on('resize', adjustFormLayout);
+
+    window.addEventListener('resize', adjustFormLayout);
     adjustFormLayout();
 });

--- a/assets/js/ufsc-admin-ui.js
+++ b/assets/js/ufsc-admin-ui.js
@@ -1,12 +1,17 @@
 
-jQuery(function($){
+document.addEventListener('DOMContentLoaded', () => {
   // Add titles for truncated cells
-  $('.ufsc-table td, .ufsc-table th').each(function(){
-    var $c = $(this);
-    if (!$c.attr('title')) { $c.attr('title', $.trim($c.text())); }
+  document.querySelectorAll('.ufsc-table td, .ufsc-table th').forEach(c => {
+    if (!c.getAttribute('title')) {
+      c.setAttribute('title', c.textContent.trim());
+    }
   });
-  var $tn = $('.wrap .tablenav.top');
-  if ($tn.length) {
-    $tn.css({ position: 'sticky', top: '32px', zIndex: 10, background: '#fff' });
+
+  const tn = document.querySelector('.wrap .tablenav.top');
+  if (tn) {
+    tn.style.position = 'sticky';
+    tn.style.top = '32px';
+    tn.style.zIndex = '10';
+    tn.style.background = '#fff';
   }
 });

--- a/includes/admin/class-menu.php
+++ b/includes/admin/class-menu.php
@@ -69,7 +69,7 @@ class UFSC_Menu
             
         // Enqueue enhanced admin UI styles/scripts for UFSC screens
         wp_enqueue_style('ufsc-admin-ui', plugins_url('../../assets/css/ufsc-admin-ui.css', __FILE__), [], '1.0.0');
-        wp_enqueue_script('ufsc-admin-ui', plugins_url('../../assets/js/ufsc-admin-ui.js', __FILE__), ['jquery'], '1.0.0', true);
+        wp_enqueue_script('ufsc-admin-ui', plugins_url('../../assets/js/ufsc-admin-ui.js', __FILE__), [], '1.0.0', true);
     
             wp_localize_script('ufsc-licence-actions', 'ufscLicenceConfig', [
                 'ajaxUrl' => admin_url('admin-ajax.php'),

--- a/includes/clubs/admin-club-list-page.php
+++ b/includes/clubs/admin-club-list-page.php
@@ -39,7 +39,7 @@ function ufsc_render_club_list_page()
     wp_enqueue_script(
         'datatables-js',
         'https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js',
-        ['jquery'],
+        [],
         '1.13.6',
         true
     );
@@ -83,7 +83,7 @@ function ufsc_render_club_list_page()
     wp_enqueue_script(
         'ufsc-admin-script',
         UFSC_PLUGIN_URL . 'assets/js/admin.js',
-        ['jquery', 'ufsc-datatables-config'],
+        ['ufsc-datatables-config'],
         UFSC_GESTION_CLUB_VERSION,
         true
     );

--- a/includes/licences/admin-licence-list.php
+++ b/includes/licences/admin-licence-list.php
@@ -50,7 +50,7 @@ wp_enqueue_style(
 wp_enqueue_script(
     'datatables-js',
     'https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js',
-    ['jquery'],
+    [],
     '1.13.6',
     true
 );

--- a/includes/overrides_profix/admin-enqueue.php
+++ b/includes/overrides_profix/admin-enqueue.php
@@ -5,5 +5,5 @@ add_action('admin_enqueue_scripts',function(){
     wp_localize_script('ufsc-admin-profix','UFSC_ADMIN',array('ajaxUrl'=>admin_url('admin-ajax.php'),'nonce'=>wp_create_nonce('ufsc_admin_licence_action')));
     wp_enqueue_script('ufsc-admin-profix');
     wp_enqueue_style('ufsc-admin-ui',plugins_url('../../assets/css/ufsc-admin-ui.css',__FILE__),[], '1.0.0');
-    wp_enqueue_script('ufsc-admin-ui',plugins_url('../../assets/js/ufsc-admin-ui.js',__FILE__),['jquery'],'1.0.0',true);
+    wp_enqueue_script('ufsc-admin-ui',plugins_url('../../assets/js/ufsc-admin-ui.js',__FILE__),[], '1.0.0',true);
 },20);


### PR DESCRIPTION
## Summary
- rewrite licence form handlers using `document.querySelector`/`addEventListener`
- convert dashboard search and admin UI helpers to vanilla JS
- remove jQuery from script enqueues in admin PHP files

## Testing
- `php -l includes/licences/admin-licence-list.php`
- `php -l includes/clubs/admin-club-list-page.php`
- `php -l includes/overrides_profix/admin-enqueue.php`
- `php -l includes/admin/class-menu.php`
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Invalid value for option "output.inlineDynamicImports" - multiple inputs are not supported when "output.inlineDynamicImports" is true)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3770ae98832bbc4de6812c77a733