### PR TITLE
feat: centralize nonce handling and document tokens

### DIFF
--- a/Plugin_UFSC_GESTION_CLUB_13072025.php
+++ b/Plugin_UFSC_GESTION_CLUB_13072025.php
@@ -67,6 +67,7 @@ if (!defined('UFSC_LICENCE_MODE')) {
 require_once UFSC_PLUGIN_PATH . 'includes/helpers/class-ufsc-csv-export.php';
 require_once UFSC_PLUGIN_PATH . 'includes/helpers/ufsc-upload-validator.php';
 require_once UFSC_PLUGIN_PATH . 'includes/helpers/attestations-helper.php';
+require_once UFSC_PLUGIN_PATH . 'includes/helpers/security.php';
 
 // Compatibility shims
 require_once UFSC_PLUGIN_PATH . 'includes/compat/monetico-compat.php';

--- a/README.md
+++ b/README.md
@@ -523,6 +523,18 @@ Pour exécuter les tests unitaires :
 phpunit --testsuite core
 ```
 
+## 🔐 Nonces Frontend
+
+| Action | Nonce | Vérification |
+| --- | --- | --- |
+| Ajout d'un licencié au panier | `ufsc_add_licencie_nonce` | `check_ajax_referer` |
+| Brouillons de licence / quota | `ufsc_front_nonce` | `check_ajax_referer` |
+| Liste des licences (actions directes) | `ufscx_licences` | `check_ajax_referer` |
+| Téléversement du logo de club | `ufsc_set_club_logo_nonce` | `check_ajax_referer` |
+| Formulaire d'affiliation | `ufsc_affiliation_nonce` | `check_ajax_referer` |
+| Soumission du formulaire licence | `ufsc_add_licence_nonce` | `check_admin_referer` |
+| Ajout de licence au panier | `ufsc_add_licence_to_cart` | `check_ajax_referer` |
+
 ## 📄 Licence
 
 Ce plugin est distribué sous licence GPL-2.0+. Voir le fichier [LICENSE](LICENSE) pour plus de détails.

--- a/includes/frontend/ajax/licence-add.php
+++ b/includes/frontend/ajax/licence-add.php
@@ -17,7 +17,7 @@ if (!defined('ABSPATH')) {
 function ufsc_handle_add_licencie_to_cart() {
     try {
         // Verify nonce
-        if (!isset($_POST['nonce']) || !wp_verify_nonce($_POST['nonce'], 'ufsc_add_licencie_nonce')) {
+        if (!ufsc_check_ajax_nonce('ufsc_add_licencie_nonce', 'nonce', false)) {
             wp_send_json_error(['message' => 'Erreur de sécurité. Veuillez recharger la page.']);
             return;
         }

--- a/includes/frontend/ajax/licence-drafts.php
+++ b/includes/frontend/ajax/licence-drafts.php
@@ -9,6 +9,9 @@ if ( ! defined('ABSPATH') ) exit;
  * Optionally accepts: licence_id (to update)
  */
 function ufsc_ajax_save_draft(){
+    if ( ! ufsc_check_ajax_nonce('ufsc_front_nonce', '_ajax_nonce', false) ) {
+        wp_send_json_error( array('message' => __('Jeton invalide.', 'plugin-ufsc-gestion-club-13072025')) );
+    }
     if ( ! is_user_logged_in() ) {
         wp_send_json_error( array('message' => __('Connexion requise.', 'plugin-ufsc-gestion-club-13072025')) );
     }
@@ -98,6 +101,9 @@ add_action('wp_ajax_nopriv_ufsc_save_licence_draft', 'ufsc_ajax_save_draft');
  * Delete a draft (only if belongs to current user's club)
  */
 function ufsc_ajax_delete_draft(){
+    if ( ! ufsc_check_ajax_nonce('ufsc_front_nonce', '_ajax_nonce', false) ) {
+        wp_send_json_error( array('message' => __('Jeton invalide.', 'plugin-ufsc-gestion-club-13072025')) );
+    }
     if ( ! is_user_logged_in() ) {
         wp_send_json_error( array('message' => __('Connexion requise.', 'plugin-ufsc-gestion-club-13072025')) );
     }

--- a/includes/frontend/ajax/licenses-direct.php
+++ b/includes/frontend/ajax/licenses-direct.php
@@ -4,7 +4,7 @@ if (!defined('ABSPATH')) exit;
 // Toggle quota
 add_action('wp_ajax_ufscx_toggle_quota','ufscx_toggle_quota');
 function ufscx_toggle_quota(){
-    check_ajax_referer('ufscx_licences');
+    ufsc_check_ajax_nonce('ufscx_licences','nonce');
     $id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
     if (!$id) wp_send_json_error(['message'=>'ID manquant']);
 
@@ -23,7 +23,7 @@ function ufscx_toggle_quota(){
 // Delete draft
 add_action('wp_ajax_ufscx_delete_draft','ufscx_delete_draft');
 function ufscx_delete_draft(){
-    check_ajax_referer('ufscx_licences');
+    ufsc_check_ajax_nonce('ufscx_licences','nonce');
     $id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
     global $wpdb; $t = $wpdb->prefix.'ufsc_licences';
     $row = $wpdb->get_row($wpdb->prepare("SELECT id, club_id, statut FROM $t WHERE id=%d", $id));

--- a/includes/frontend/ajax/logo-upload.php
+++ b/includes/frontend/ajax/logo-upload.php
@@ -3,7 +3,7 @@
 if (!defined('ABSPATH')) { exit; }
 
 function ufsc_handle_set_club_logo() {
-    if (!isset($_POST['nonce']) || !wp_verify_nonce($_POST['nonce'], 'ufsc_set_club_logo_nonce')) {
+    if (!ufsc_check_ajax_nonce('ufsc_set_club_logo_nonce', 'nonce', false)) {
         wp_send_json_error(['message' => 'Erreur de sécurité. Veuillez recharger la page.']);
     }
     if (!is_user_logged_in()) {

--- a/includes/frontend/ajax/quota.php
+++ b/includes/frontend/ajax/quota.php
@@ -3,7 +3,7 @@ if (!defined('ABSPATH')) exit;
 
 add_action('wp_ajax_ufsc_include_quota', 'ufsc_ajax_include_quota');
 function ufsc_ajax_include_quota(){
-    if (!check_ajax_referer('ufsc_front_nonce', '_ajax_nonce', false)) wp_send_json_error('Bad nonce',403);
+    if (!ufsc_check_ajax_nonce('ufsc_front_nonce', '_ajax_nonce', false)) wp_send_json_error('Bad nonce',403);
     if (!is_user_logged_in()) wp_send_json_error('Non connecté',401);
 
     $licence_id = isset($_POST['licence_id']) ? absint($_POST['licence_id']) : 0;

--- a/includes/frontend/forms/affiliation-form-render.php
+++ b/includes/frontend/forms/affiliation-form-render.php
@@ -86,8 +86,8 @@ function ufsc_render_affiliation_form($args = [])
     $regions_file = plugin_dir_path(__FILE__) . '../../../data/regions.php';
     $regions = file_exists($regions_file) ? require $regions_file : [];
     
-    // Generate nonce
-    $nonce = wp_create_nonce('ufsc_affiliation_nonce');
+    // Generate nonce for AJAX submission
+    $nonce = ufsc_create_nonce('ufsc_affiliation_nonce');
     
     // Start form output
     $output = '';
@@ -104,7 +104,7 @@ function ufsc_render_affiliation_form($args = [])
     }
     
     $output .= '<form id="' . esc_attr($args['form_id']) . '" class="ufsc-affiliation-form" method="post">';
-    $output .= wp_nonce_field('ufsc_affiliation_nonce', '_ufsc_affiliation_nonce', true, false);
+    $output .= ufsc_nonce_field('ufsc_affiliation_nonce');
     $output .= '<input type="hidden" name="action" value="ufsc_add_affiliation_to_cart">';
     $output .= '<input type="hidden" name="context" value="' . esc_attr($args['context']) . '">';
     $output .= '<input type="hidden" name="is_renewal" value="' . ($is_renewal ? '1' : '0') . '">';

--- a/includes/frontend/forms/licence-form-render.php
+++ b/includes/frontend/forms/licence-form-render.php
@@ -45,8 +45,8 @@ function ufsc_render_licence_form($args = array()){
     <?php endif; ?>
 
     <form id="<?php echo esc_attr($args['form_id']); ?>" class="ufsc-licence-form ufsc-licence-form ufsc-form" method="post" action="<?php echo esc_url( get_permalink() ); ?>">
-      <?php wp_nonce_field('ufsc_add_licence_nonce', 'ufsc_nonce'); ?>
-      <?php wp_nonce_field('ufsc_add_licence_to_cart', '_ufsc_licence_nonce'); ?>
+      <?php echo ufsc_nonce_field('ufsc_add_licence_nonce'); ?>
+      <?php echo ufsc_nonce_field('ufsc_add_licence_to_cart', '_ufsc_licence_nonce'); ?>
       <input type="hidden" name="action" value="ufsc_submit_licence">
       <input type="hidden" name="club_id" value="<?php echo esc_attr($club->id); ?>">
       <input type="hidden" name="context" value="<?php echo esc_attr($args['context']); ?>">

--- a/includes/frontend/handlers/submit-licence.php
+++ b/includes/frontend/handlers/submit-licence.php
@@ -3,7 +3,9 @@ if (!defined('ABSPATH')) exit;
 
 function ufsc_handle_front_licence_submit(){
     if (!isset($_POST['action']) || $_POST['action']!=='ufsc_submit_licence') return;
-    if (!isset($_POST['ufsc_nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['ufsc_nonce'])), 'ufsc_add_licence_nonce')){ wp_die(__('Nonce invalide.','plugin-ufsc-gestion-club-13072025')); }
+    if (!ufsc_check_admin_nonce('ufsc_add_licence_nonce', 'ufsc_nonce', false)){
+        wp_die(__('Nonce invalide.','plugin-ufsc-gestion-club-13072025'));
+    }
     if (!is_user_logged_in()){ wp_safe_redirect( wp_login_url() ); exit; }
 
     $fields = array('nom','prenom','date_naissance','sexe','lieu_naissance','email','adresse','suite_adresse','code_postal','ville','tel_mobile','identifiant_laposte','profession','fonction','competition','licence_delegataire','numero_licence_delegataire','diffusion_image','infos_fsasptt','infos_asptt','infos_cr','infos_partenaires','honorabilite','assurance_dommage_corporel','assurance_assistance','ufsc_rules_ack');

--- a/includes/frontend/hooks/form-capture.php
+++ b/includes/frontend/hooks/form-capture.php
@@ -12,7 +12,7 @@ add_action('template_redirect', function(){
     if ($_SERVER['REQUEST_METHOD'] !== 'POST') return;
     if (empty($_POST['action']) || $_POST['action'] !== 'ufsc_submit_licence') return;
 
-    if (!isset($_POST['ufsc_nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['ufsc_nonce'])), 'ufsc_add_licence_nonce')){
+    if (!ufsc_check_admin_nonce('ufsc_add_licence_nonce', 'ufsc_nonce', false)){
         wp_die(__('Jeton de sécurité invalide.','plugin-ufsc-gestion-club-13072025'));
     }
     if (!is_user_logged_in()){ wp_safe_redirect( wp_login_url( get_permalink() ) ); exit; }

--- a/includes/frontend/shortcodes/ajouter-licencie-shortcode.php
+++ b/includes/frontend/shortcodes/ajouter-licencie-shortcode.php
@@ -196,7 +196,7 @@ function ufsc_enqueue_add_licencie_assets()
     // Localize script with AJAX data
     wp_localize_script('ufsc-add-licencie', 'ufscAjax', [
         'ajaxUrl' => admin_url('admin-ajax.php'),
-        'addLicencieNonce' => wp_create_nonce('ufsc_add_licencie_nonce')
+        'addLicencieNonce' => ufsc_create_nonce('ufsc_add_licencie_nonce')
     ]);
     
     // Enqueue frontend styles if available

--- a/includes/frontend/shortcodes/dashboard-mvp-broken.php
+++ b/includes/frontend/shortcodes/dashboard-mvp-broken.php
@@ -276,7 +276,7 @@ function ufsc_render_dashboard_statistics($club) {
                         <div class="ufsc-stat-bar">
                             <div class="ufsc-stat-label"><?php echo esc_html($age_group); ?></div>
                             <div class="ufsc-bar-container">
-                                <div class="ufsc-bar-fill" style="width: <?php echo $percentage; %>%"></div>
+                                <div class="ufsc-bar-fill" style="width: <?php echo $percentage; ?>%"></div>
                             </div>
                             <div class="ufsc-stat-value"><?php echo $count; ?> (<?php echo $percentage; ?>%)</div>
                         </div>
@@ -296,7 +296,7 @@ function ufsc_render_dashboard_statistics($club) {
                         <div class="ufsc-stat-bar">
                             <div class="ufsc-stat-label"><?php echo $type_label; ?></div>
                             <div class="ufsc-bar-container">
-                                <div class="ufsc-bar-fill" style="width: <?php echo $percentage; %>%"></div>
+                                <div class="ufsc-bar-fill" style="width: <?php echo $percentage; ?>%"></div>
                             </div>
                             <div class="ufsc-stat-value"><?php echo $count; ?> (<?php echo $percentage; ?>%)</div>
                         </div>
@@ -428,7 +428,7 @@ function ufsc_enqueue_dashboard_mvp_assets() {
         // Localize script for AJAX
         wp_localize_script('ufsc-club-logo', 'ufscLogoUpload', [
             'ajaxUrl' => admin_url('admin-ajax.php'),
-            'setLogoNonce' => wp_create_nonce('ufsc_set_club_logo_nonce'),
+            'setLogoNonce' => ufsc_create_nonce('ufsc_set_club_logo_nonce'),
             'maxSizeMB' => 2
         ]);
     }

--- a/includes/frontend/shortcodes/dashboard-mvp.php
+++ b/includes/frontend/shortcodes/dashboard-mvp.php
@@ -440,7 +440,7 @@ function ufsc_enqueue_dashboard_mvp_assets() {
         // Localize script for AJAX
         wp_localize_script('ufsc-club-logo', 'ufscLogoUpload', [
             'ajaxUrl' => admin_url('admin-ajax.php'),
-            'setLogoNonce' => wp_create_nonce('ufsc_set_club_logo_nonce'),
+            'setLogoNonce' => ufsc_create_nonce('ufsc_set_club_logo_nonce'),
             'maxSizeMB' => 2
         ]);
     }

--- a/includes/frontend/shortcodes/licenses-direct.php
+++ b/includes/frontend/shortcodes/licenses-direct.php
@@ -52,7 +52,7 @@ function ufscx_licences_direct_shortcode($atts){
     wp_enqueue_script('ufscx-licences-direct', plugins_url('../../../assets/js/ufsc-licenses-direct.js', __FILE__), ['jquery'], '1.0', true);
     wp_localize_script('ufscx-licences-direct', 'UFSCX_AJAX', [
         'ajax' => admin_url('admin-ajax.php'),
-        'nonce' => wp_create_nonce('ufscx_licences'),
+        'nonce' => ufsc_create_nonce('ufscx_licences'),
     ]);
 
     // Fetch data

--- a/includes/frontend/woocommerce-affiliation-form.php
+++ b/includes/frontend/woocommerce-affiliation-form.php
@@ -52,7 +52,7 @@ add_action('woocommerce_before_add_to_cart_button', 'ufsc_add_affiliation_form_t
 function ufsc_handle_affiliation_form_submission()
 {
     // Verify nonce
-    if (!wp_verify_nonce($_POST['_ufsc_affiliation_nonce'] ?? '', 'ufsc_affiliation_nonce')) {
+    if (!ufsc_check_ajax_nonce('ufsc_affiliation_nonce', 'ufsc_nonce', false)) {
         wp_send_json_error('Erreur de sécurité.');
         return;
     }

--- a/includes/helpers/security.php
+++ b/includes/helpers/security.php
@@ -1,0 +1,32 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Helper functions for nonce generation and validation.
+ */
+
+if (!function_exists('ufsc_create_nonce')) {
+    function ufsc_create_nonce(string $action): string {
+        return wp_create_nonce($action);
+    }
+}
+
+if (!function_exists('ufsc_nonce_field')) {
+    function ufsc_nonce_field(string $action, string $name = 'ufsc_nonce'): string {
+        return wp_nonce_field($action, $name, true, false);
+    }
+}
+
+if (!function_exists('ufsc_check_ajax_nonce')) {
+    function ufsc_check_ajax_nonce(string $action, string $query_arg = 'ufsc_nonce', bool $die = true): bool {
+        return check_ajax_referer($action, $query_arg, $die);
+    }
+}
+
+if (!function_exists('ufsc_check_admin_nonce')) {
+    function ufsc_check_admin_nonce(string $action, string $query_arg = 'ufsc_nonce', bool $die = true): bool {
+        return check_admin_referer($action, $query_arg, $die);
+    }
+}

--- a/includes/overrides_profix/front-enqueue.php
+++ b/includes/overrides_profix/front-enqueue.php
@@ -4,7 +4,7 @@ add_action('wp_enqueue_scripts', function(){
     wp_register_script('ufsc-front-profix', plugins_url('../../assets/js/ufsc-front-profix.js', __FILE__), array('jquery'), '20.6.0', true);
     wp_localize_script('ufsc-front-profix','UFSC_PRO',array(
         'ajaxUrl'=>admin_url('admin-ajax.php'),
-        'nonce'=>wp_create_nonce('ufsc_front_nonce'),
+        'nonce'=>ufsc_create_nonce('ufsc_front_nonce'),
         'i18n'=>array('saved'=>__('Brouillon enregistré.','plugin-ufsc-gestion-club-13072025'),'deleted'=>__('Brouillon supprimé.','plugin-ufsc-gestion-club-13072025'),'error'=>__('Une erreur est survenue.','plugin-ufsc-gestion-club-13072025'))
     ));
     wp_enqueue_script('ufsc-front-profix');


### PR DESCRIPTION
## Summary
- add security helper for nonce generation and checks
- enforce nonce verification in frontend AJAX and forms
- document frontend nonces in README

## Testing
- `php -l includes/helpers/security.php`
- `phpunit --testsuite core` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3786e4a8832b87405b3e2ac3c1fa