### PR TITLE
Use unified affiliation product ID option

### DIFF
--- a/Plugin_UFSC_GESTION_CLUB_13072025.php
+++ b/Plugin_UFSC_GESTION_CLUB_13072025.php
@@ -1129,6 +1129,9 @@ function ufsc_gestion_club_activate()
     }
 
     // Set default WooCommerce product IDs
+    if (!get_option('ufsc_wc_affiliation_product_id')) {
+        add_option('ufsc_wc_affiliation_product_id', 4823);
+    }
     if (!get_option('ufsc_affiliation_product_id')) {
         add_option('ufsc_affiliation_product_id', 4823);
     }

--- a/includes/admin/class-menu.php
+++ b/includes/admin/class-menu.php
@@ -1981,7 +1981,7 @@ class UFSC_Menu
         ));
 
         // Register WooCommerce product ID settings
-        register_setting('ufsc_settings', 'ufsc_affiliation_product_id', array(
+        register_setting('ufsc_settings', 'ufsc_wc_affiliation_product_id', array(
             'sanitize_callback' => 'absint',
             'default' => 4823
         ));
@@ -3912,9 +3912,9 @@ class UFSC_Menu
      */
     public function affiliation_product_id_callback()
     {
-        $product_id = get_option('ufsc_affiliation_product_id', 4823);
+        $product_id = ufsc_get_affiliation_product_id_safe();
         ?>
-        <input type="number" id="ufsc_affiliation_product_id" name="ufsc_affiliation_product_id" 
+        <input type="number" id="ufsc_wc_affiliation_product_id" name="ufsc_wc_affiliation_product_id"
                value="<?php echo esc_attr($product_id); ?>" min="1" step="1" />
         <p class="description">
             <?php esc_html_e('ID du produit WooCommerce pour les affiliations de club (par défaut: 4823).', 'plugin-ufsc-gestion-club-13072025'); ?>

--- a/includes/class-ufsc-woocommerce-integration.php
+++ b/includes/class-ufsc-woocommerce-integration.php
@@ -64,7 +64,7 @@ class UFSC_WooCommerce_Integration {
      */
     private function init() {
         // Get product IDs from options with fallback to constants
-        $this->affiliation_product_id = get_option('ufsc_wc_affiliation_product_id', 4823);
+        $this->affiliation_product_id = ufsc_get_affiliation_product_id_safe();
         $license_product_ids = get_option('ufsc_wc_license_product_ids', '2934');
         
         // Support comma-separated list of license product IDs

--- a/includes/compat/wc-id-reconciliation.php
+++ b/includes/compat/wc-id-reconciliation.php
@@ -116,12 +116,5 @@ function ufsc_get_licence_product_id_safe() {
  * @return int Affiliation product ID
  */
 function ufsc_get_affiliation_product_id_safe() {
-    $affiliation_id = ufsc_get_affiliation_product_id();
-    
-    // If no ID found in old option, try new option
-    if (!$affiliation_id) {
-        $affiliation_id = get_option('ufsc_wc_affiliation_product_id', 0);
-    }
-    
-    return (int) $affiliation_id;
+    return (int) ufsc_get_affiliation_product_id();
 }

--- a/includes/frontend/affiliation-woocommerce.php
+++ b/includes/frontend/affiliation-woocommerce.php
@@ -48,7 +48,7 @@ if (!function_exists('ufsc_add_affiliation_to_cart')) {
         ];
 
         // Ajouter au panier (using configurable product ID)
-        $added = WC()->cart->add_to_cart(ufsc_get_affiliation_product_id(), 1, 0, [], $cart_item_data);
+        $added = WC()->cart->add_to_cart(ufsc_get_affiliation_product_id_safe(), 1, 0, [], $cart_item_data);
 
         return $added;
     }
@@ -104,7 +104,7 @@ if (!function_exists('ufsc_process_affiliation_order')) {
             $product_id = $item->get_product_id();
 
             // Vérifier si c'est une affiliation UFSC
-            if ($product_id == ufsc_get_affiliation_product_id()) {
+            if ($product_id == ufsc_get_affiliation_product_id_safe()) {
                 $club_id = $item->get_meta('ufsc_club_id');
 
                 if ($club_id) {

--- a/includes/frontend/forms/affiliation-form-render.php
+++ b/includes/frontend/forms/affiliation-form-render.php
@@ -61,7 +61,7 @@ function ufsc_render_affiliation_form($args = [])
     
     // If this is a shortcode context and not on product page, redirect to product
     if ($args['context'] === 'shortcode' && $args['redirect_to_product']) {
-        $product_url = get_permalink(wc_get_product(ufsc_get_affiliation_product_id()));
+        $product_url = get_permalink(wc_get_product(ufsc_get_affiliation_product_id_safe()));
         if ($product_url) {
             $action_text = $is_renewal ? 'Renouveler l\'affiliation' : 'Procéder à l\'affiliation';
             return '<div class="ufsc-container"><div class="ufsc-grid"><div class="ufsc-card"><div class="ufsc-alert ufsc-alert-info">'
@@ -75,7 +75,7 @@ function ufsc_render_affiliation_form($args = [])
     // Check if there's already an affiliation product in cart
     if (function_exists('WC') && WC()->cart) {
         foreach (WC()->cart->get_cart() as $cart_item) {
-            if (isset($cart_item['product_id']) && $cart_item['product_id'] == ufsc_get_affiliation_product_id()) {
+            if (isset($cart_item['product_id']) && $cart_item['product_id'] == ufsc_get_affiliation_product_id_safe()) {
                 return '<div class="ufsc-container"><div class="ufsc-grid"><div class="ufsc-card"><div class="ufsc-alert ufsc-alert-warning">'
                     . '<h4>Affiliation en cours</h4>'
                     . '<p>Une demande d\'affiliation est déjà dans votre panier.</p>'

--- a/includes/frontend/shortcodes/affiliation-form-shortcode.php
+++ b/includes/frontend/shortcodes/affiliation-form-shortcode.php
@@ -68,7 +68,7 @@ if (!function_exists('ufsc_add_affiliation_to_cart')) {
     function ufsc_add_affiliation_to_cart($club_id)
     {
         // ID du produit "Pack Affiliation"
-        $product_id = get_option('ufsc_affiliation_product_id', 0);
+        $product_id = ufsc_get_affiliation_product_id_safe();
 
         if (!$product_id) {
             return false;

--- a/includes/frontend/woocommerce-affiliation-form.php
+++ b/includes/frontend/woocommerce-affiliation-form.php
@@ -25,7 +25,7 @@ function ufsc_add_affiliation_form_to_product_page()
     global $product;
 
     // Check if this is the affiliation product
-    if (!$product || $product->get_id() != ufsc_get_affiliation_product_id()) {
+    if (!$product || $product->get_id() != ufsc_get_affiliation_product_id_safe()) {
         return;
     }
 
@@ -75,7 +75,7 @@ function ufsc_handle_affiliation_form_submission()
 
     // Check for existing affiliation in cart
     foreach (WC()->cart->get_cart() as $cart_item) {
-        if (isset($cart_item['product_id']) && $cart_item['product_id'] == ufsc_get_affiliation_product_id()) {
+        if (isset($cart_item['product_id']) && $cart_item['product_id'] == ufsc_get_affiliation_product_id_safe()) {
             wp_send_json_error('Une demande d\'affiliation est déjà dans votre panier.');
             return;
         }
@@ -138,7 +138,7 @@ function ufsc_handle_affiliation_form_submission()
         'unique_key' => $unique_key
     ];
 
-    $added = WC()->cart->add_to_cart(ufsc_get_affiliation_product_id(), 1, 0, [], $cart_item_data);
+    $added = WC()->cart->add_to_cart(ufsc_get_affiliation_product_id_safe(), 1, 0, [], $cart_item_data);
 
     if ($added) {
         wp_send_json_success([
@@ -156,7 +156,7 @@ add_action('wp_ajax_ufsc_add_affiliation_to_cart', 'ufsc_handle_affiliation_form
  */
 function ufsc_add_affiliation_data_from_session($cart_item_data, $product_id, $variation_id)
 {
-    if ($product_id == ufsc_get_affiliation_product_id()) {
+    if ($product_id == ufsc_get_affiliation_product_id_safe()) {
         $affiliation_data = WC()->session->get('ufsc_pending_affiliation_data');
         
         if ($affiliation_data && is_array($affiliation_data)) {
@@ -232,7 +232,7 @@ function ufsc_process_affiliation_after_payment($order_id)
         $product_id = $item->get_product_id();
 
         // Check if this is an affiliation
-        if ($product_id == ufsc_get_affiliation_product_id()) {
+        if ($product_id == ufsc_get_affiliation_product_id_safe()) {
             ufsc_create_or_update_club_from_order_item($item, $order);
         }
     }
@@ -298,10 +298,10 @@ function ufsc_create_or_update_club_from_order_item($item, $order)
  */
 function ufsc_prevent_multiple_affiliations($passed, $product_id)
 {
-    if ($product_id == ufsc_get_affiliation_product_id()) {
+    if ($product_id == ufsc_get_affiliation_product_id_safe()) {
         // Check if affiliation is already in cart
         foreach (WC()->cart->get_cart() as $cart_item) {
-            if (isset($cart_item['product_id']) && $cart_item['product_id'] == ufsc_get_affiliation_product_id()) {
+            if (isset($cart_item['product_id']) && $cart_item['product_id'] == ufsc_get_affiliation_product_id_safe()) {
                 wc_add_notice('Une demande d\'affiliation est déjà dans votre panier.', 'error');
                 return false;
             }

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -748,7 +748,10 @@ add_action('admin_notices', 'ufsc_admin_page_configuration_notices');
  */
 function ufsc_get_affiliation_product_id()
 {
-    $product_id = get_option('ufsc_affiliation_product_id', 4823);
+    $product_id = get_option('ufsc_wc_affiliation_product_id', 0);
+    if (!$product_id) {
+        $product_id = get_option('ufsc_affiliation_product_id', 4823);
+    }
     return (int) $product_id;
 }
 

--- a/includes/helpers/helpers-product-buttons.php
+++ b/includes/helpers/helpers-product-buttons.php
@@ -100,7 +100,7 @@ function ufsc_render_product_button($product_id, $label, $classes = '', $context
             // Check if affiliation is already in cart
             if (function_exists('WC') && WC()->cart) {
                 foreach (WC()->cart->get_cart() as $cart_item) {
-                    if (isset($cart_item['product_id']) && $cart_item['product_id'] == ufsc_get_affiliation_product_id()) {
+                    if (isset($cart_item['product_id']) && $cart_item['product_id'] == ufsc_get_affiliation_product_id_safe()) {
                         return ufsc_render_disabled_button($label, $classes, 'En cours', 'Une demande d\'affiliation est déjà dans votre panier.');
                     }
                 }
@@ -212,7 +212,7 @@ function ufsc_generate_affiliation_button($args = [])
     }
 
     return ufsc_render_product_button(
-        ufsc_get_affiliation_product_id(),
+        ufsc_get_affiliation_product_id_safe(),
         $args['label'],
         $args['classes'],
         $args['context'],
@@ -292,7 +292,7 @@ function ufsc_generate_cart_aware_button($product_id, $label, $options = [])
     $context = 'general';
     if ($product_id == ufsc_get_licence_product_id()) {
         $context = 'licence';
-    } elseif ($product_id == ufsc_get_affiliation_product_id()) {
+    } elseif ($product_id == ufsc_get_affiliation_product_id_safe()) {
         $context = 'affiliation';
     }
 

--- a/includes/woocommerce/auto-pack-affiliation.php
+++ b/includes/woocommerce/auto-pack-affiliation.php
@@ -57,7 +57,7 @@ class UFSC_Auto_Pack_Affiliation {
      * @return int
      */
     private function get_affiliation_product_id() {
-        return get_option('ufsc_wc_affiliation_product_id', 4823);
+        return ufsc_get_affiliation_product_id_safe();
     }
     
     /**


### PR DESCRIPTION
## Summary
- read `ufsc_wc_affiliation_product_id` with fallback to legacy option
- expose unified `ufsc_get_affiliation_product_id_safe` utility
- update admin settings and calls to use the safe ID retrieval

## Testing
- `php -l includes/helpers.php`
- `php -l includes/compat/wc-id-reconciliation.php`
- `php -l includes/helpers/helpers-product-buttons.php`
- `php -l includes/frontend/woocommerce-affiliation-form.php`
- `php -l includes/frontend/affiliation-woocommerce.php`
- `php -l includes/frontend/forms/affiliation-form-render.php`
- `php -l includes/frontend/shortcodes/affiliation-form-shortcode.php`
- `php -l includes/admin/class-menu.php`
- `php -l includes/woocommerce/auto-pack-affiliation.php`
- `php -l includes/class-ufsc-woocommerce-integration.php`
- `php -l Plugin_UFSC_GESTION_CLUB_13072025.php`
- `phpunit` *(fails: command not found)*
- `npm test` *(fails: missing script test)*

------
https://chatgpt.com/codex/tasks/task_e_68ae45471f88832b8f5c8b53e740204c