### PR TITLE
Handle bureau role accents in quota calculation

### DIFF
--- a/includes/frontend/helpers/dashboard-data.php
+++ b/includes/frontend/helpers/dashboard-data.php
@@ -161,7 +161,11 @@ function ufsc_get_quota_pack_info($club_id) {
     $inclus_used = 0;
     $bureau_used = 0;
     $bureau_note = '';
-    
+
+    if (!function_exists('remove_accents')) {
+        require_once ABSPATH . WPINC . '/formatting.php';
+    }
+
     foreach ($licences as $licence) {
         // Count included licenses (assuming is_included field or using total count)
         if (!empty($licence->is_included) && $licence->is_included == 1) {
@@ -171,11 +175,9 @@ function ufsc_get_quota_pack_info($club_id) {
         // Count board members (if role field exists)
         if (!empty($licence->fonction) || !empty($licence->role)) {
             $role = $licence->fonction ?? $licence->role ?? '';
-            $role_lower = strtolower($role);
-            
-            if (strpos($role_lower, 'président') !== false || 
-                strpos($role_lower, 'secrétaire') !== false || 
-                strpos($role_lower, 'trésorier') !== false) {
+            $role_clean = strtolower(remove_accents($role));
+
+            if (in_array($role_clean, ['president', 'secretaire', 'tresorier'], true)) {
                 $bureau_used++;
             }
         }


### PR DESCRIPTION
## Summary
- Normalize club bureau role names with `remove_accents` and `strtolower`
- Count bureau members using strict role matches for president, secretaire and tresorier
- Ensure WordPress `remove_accents` helper is available when computing quotas

## Testing
- `php -l includes/frontend/helpers/dashboard-data.php`
- `phpunit` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `php -r "function remove_accents($s){return iconv('UTF-8','ASCII//TRANSLIT',$s);} $roles=['président','president','secrétaire','secretaire','trésorier','tresorier']; $count=0; foreach($roles as $r){ $clean=strtolower(remove_accents($r)); if (in_array($clean,['president','secretaire','tresorier'],true)){ $count++; echo $r.' -> '.$clean.' counted'.PHP_EOL; } else { echo $r.' -> '.$clean.' not counted'.PHP_EOL; } } echo 'bureau_used='.$count.PHP_EOL;"`

------
https://chatgpt.com/codex/tasks/task_e_68ae4d5c75e0832bbc48d3306770168f