### PR TITLE
chore: align plugin version constants

### DIFF
--- a/Plugin_UFSC_GESTION_CLUB_13072025.php
+++ b/Plugin_UFSC_GESTION_CLUB_13072025.php
@@ -12,9 +12,9 @@ if (!defined('UFSC_ENABLE_DIAG_ENDPOINT')) define('UFSC_ENABLE_DIAG_ENDPOINT', f
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain: plugin-ufsc-gestion-club-13072025
  * Domain Path: /languages
- * Requires at least: 5.5
+ * Requires at least: 6.6
  * Tested up to: 6.8
- * Requires PHP: 7.4
+ * Requires PHP: 8.3
  * Network: false
  */
 
@@ -24,7 +24,6 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define('UFSC_GESTION_CLUB_VERSION', '1.3.0');
 define('UFSC_PLUGIN_PATH', plugin_dir_path(__FILE__));
 
 // Global helper functions (including ufsc_verify_club_access)
@@ -229,7 +228,7 @@ function ufsc_gestion_club_admin_enqueue_scripts($hook)
         'ufsc-admin-style',
         UFSC_PLUGIN_URL . 'assets/css/admin.css',
         [],
-        UFSC_GESTION_CLUB_VERSION
+        UFSC_PLUGIN_VERSION
     );
     
     // Enqueue admin fixes CSS
@@ -237,7 +236,7 @@ function ufsc_gestion_club_admin_enqueue_scripts($hook)
         'ufsc-admin-fixes',
         UFSC_PLUGIN_URL . 'assets/css/admin-fixes.css',
         ['ufsc-admin-style'],
-        UFSC_GESTION_CLUB_VERSION
+        UFSC_PLUGIN_VERSION
     );
 
     // Enqueue WordPress media scripts on edit club page
@@ -258,7 +257,7 @@ function ufsc_gestion_club_admin_enqueue_scripts($hook)
         'ufsc-admin-script',
         UFSC_PLUGIN_URL . 'assets/js/admin.js',
         ['jquery'],
-        UFSC_GESTION_CLUB_VERSION,
+        UFSC_PLUGIN_VERSION,
         true
     );
 
@@ -268,7 +267,7 @@ function ufsc_gestion_club_admin_enqueue_scripts($hook)
             'ufsc-attestations',
             UFSC_PLUGIN_URL . 'assets/js/ufsc-attestations.js',
             ['jquery'],
-            UFSC_GESTION_CLUB_VERSION,
+            UFSC_PLUGIN_VERSION,
             true
         );
         
@@ -756,7 +755,7 @@ function ufsc_gestion_club_enqueue_scripts()
         'ufsc-charts-script',
         UFSC_PLUGIN_URL . 'assets/js/ufsc-charts.js',
         ['jquery'],
-        UFSC_GESTION_CLUB_VERSION,
+        UFSC_PLUGIN_VERSION,
         true
     );
 
@@ -818,14 +817,14 @@ function ufsc_enqueue_form_enhancements()
             'ufsc-form-enhancements-style',
             UFSC_PLUGIN_URL . 'assets/css/form-enhancements.css',
             ['ufsc-frontend-style'],
-            UFSC_GESTION_CLUB_VERSION
+            UFSC_PLUGIN_VERSION
         );
 
         wp_enqueue_script(
             'ufsc-form-enhancements-script',
             UFSC_PLUGIN_URL . 'assets/js/form-enhancements.js',
             ['jquery', 'ufsc-frontend-script'],
-            UFSC_GESTION_CLUB_VERSION,
+            UFSC_PLUGIN_VERSION,
             true
         );
         
@@ -857,7 +856,7 @@ function ufsc_enqueue_frontend_pro_assets()
         'ufsc-frontend-pro-style',
         UFSC_PLUGIN_URL . 'assets/css/frontend-pro.css',
         ['ufsc-frontend-style'],
-        UFSC_GESTION_CLUB_VERSION
+        UFSC_PLUGIN_VERSION
     );
 
     // Enqueue enhanced license form styles
@@ -865,7 +864,7 @@ function ufsc_enqueue_frontend_pro_assets()
         'ufsc-licence-form-enhanced',
         UFSC_PLUGIN_URL . 'assets/css/licence-form-enhanced.css',
         ['ufsc-frontend-pro-style'],
-        UFSC_GESTION_CLUB_VERSION
+        UFSC_PLUGIN_VERSION
     );
 
     // Enqueue new multi-licence styles
@@ -873,7 +872,7 @@ function ufsc_enqueue_frontend_pro_assets()
         'ufsc-licence-styles',
         UFSC_PLUGIN_URL . 'assets/css/ufsc-licence.css',
         ['ufsc-frontend-pro-style'],
-        UFSC_GESTION_CLUB_VERSION
+        UFSC_PLUGIN_VERSION
     );
 
     // Enqueue dashboard fixes for UI improvements
@@ -881,14 +880,14 @@ function ufsc_enqueue_frontend_pro_assets()
         'ufsc-dashboard-fixes',
         UFSC_PLUGIN_URL . 'assets/css/ufsc-dashboard-fixes.css',
         ['ufsc-licence-styles'],
-        UFSC_GESTION_CLUB_VERSION
+        UFSC_PLUGIN_VERSION
     );
 
     wp_enqueue_script(
         'ufsc-frontend-pro-script',
         UFSC_PLUGIN_URL . 'assets/js/frontend-pro.js',
         ['jquery', 'ufsc-frontend-script'],
-        UFSC_GESTION_CLUB_VERSION,
+        UFSC_PLUGIN_VERSION,
         true
     );
 
@@ -897,7 +896,7 @@ function ufsc_enqueue_frontend_pro_assets()
         'ufsc-licence-multi',
         UFSC_PLUGIN_URL . 'assets/js/ufsc-licence-multi.js',
         ['jquery', 'ufsc-frontend-pro-script'],
-        UFSC_GESTION_CLUB_VERSION,
+        UFSC_PLUGIN_VERSION,
         true
     );
 
@@ -1081,7 +1080,7 @@ function ufsc_enqueue_woocommerce_styles()
             'ufsc-woocommerce-styles',
             UFSC_PLUGIN_URL . 'assets/css/woocommerce-custom.css',
             [],
-            UFSC_GESTION_CLUB_VERSION
+            UFSC_PLUGIN_VERSION
         );
     }
 }

--- a/includes/admin/class-frontend-pro-settings.php
+++ b/includes/admin/class-frontend-pro-settings.php
@@ -181,7 +181,7 @@ class UFSC_Frontend_Pro_Settings {
                         <div>
                             <h4>📊 Statut actuel</h4>
                             <ul>
-                                <li><strong>Version:</strong> <?php echo UFSC_GESTION_CLUB_VERSION; ?></li>
+                                <li><strong>Version:</strong> <?php echo UFSC_PLUGIN_VERSION; ?></li>
                                 <li><strong>Fonctionnalités pro:</strong> 
                                     <?php echo $enabled ? '<span style="color: green;">✅ Activées</span>' : '<span style="color: red;">❌ Désactivées</span>'; ?>
                                 </li>

--- a/includes/admin/class-menu.php
+++ b/includes/admin/class-menu.php
@@ -53,7 +53,7 @@ class UFSC_Menu
                 'ufsc-licence-actions',
                 UFSC_PLUGIN_URL . 'assets/js/admin-licence-actions.js',
                 ['jquery'],
-                UFSC_GESTION_CLUB_VERSION,
+                UFSC_PLUGIN_VERSION,
                 true
             );
 
@@ -62,7 +62,7 @@ class UFSC_Menu
                 'ufsc-admin-licences',
                 UFSC_PLUGIN_URL . 'assets/css/admin-licences.css',
                 [],
-                UFSC_GESTION_CLUB_VERSION
+                UFSC_PLUGIN_VERSION
             );
 
             // Localize script with nonces and AJAX URL
@@ -871,7 +871,7 @@ class UFSC_Menu
             'ufsc-admin-licence-table-style',
             UFSC_PLUGIN_URL . 'assets/css/admin-licence-table.css',
             [],
-            UFSC_GESTION_CLUB_VERSION
+            UFSC_PLUGIN_VERSION
         );
 
         require_once UFSC_PLUGIN_PATH . 'includes/licences/class-ufsc-licence-list-table.php';
@@ -1283,7 +1283,7 @@ class UFSC_Menu
             'ufsc-admin-style',
             UFSC_PLUGIN_URL . 'assets/css/admin.css',
             [],
-            UFSC_GESTION_CLUB_VERSION
+            UFSC_PLUGIN_VERSION
         );
         
         // Handle export processing
@@ -2556,14 +2556,14 @@ class UFSC_Menu
             'ufsc-licence-form-style',
             UFSC_PLUGIN_URL . 'assets/css/form-licence.css',
             [],
-            UFSC_GESTION_CLUB_VERSION
+            UFSC_PLUGIN_VERSION
         );
 
         wp_enqueue_script(
             'ufsc-licence-form-script',
             UFSC_PLUGIN_URL . 'assets/js/form-licence.js',
             ['jquery'],
-            UFSC_GESTION_CLUB_VERSION,
+            UFSC_PLUGIN_VERSION,
             true
         );
         ?>

--- a/includes/admin/class-test-helper.php
+++ b/includes/admin/class-test-helper.php
@@ -277,7 +277,7 @@ class UFSC_Test_Helper
                 'memory_limit' => ini_get('memory_limit')
             ],
             'plugin' => [
-                'version' => UFSC_GESTION_CLUB_VERSION,
+                'version' => UFSC_PLUGIN_VERSION,
                 'path' => UFSC_PLUGIN_PATH,
                 'url' => UFSC_PLUGIN_URL
             ],

--- a/includes/admin/class-ufsc-admin-settings.php
+++ b/includes/admin/class-ufsc-admin-settings.php
@@ -289,7 +289,7 @@ class UFSC_Admin_Settings {
                     </p>
                     <p>
                         <strong><?php _e('Version du plugin:', 'plugin-ufsc-gestion-club-13072025'); ?></strong> 
-                        <?php echo defined('UFSC_GESTION_CLUB_VERSION') ? UFSC_GESTION_CLUB_VERSION : '1.2.1'; ?>
+                        <?php echo defined('UFSC_PLUGIN_VERSION') ? UFSC_PLUGIN_VERSION : '20.8.1'; ?>
                     </p>
                 </div>
             </div>

--- a/includes/clubs/admin-club-list-page.php
+++ b/includes/clubs/admin-club-list-page.php
@@ -10,7 +10,7 @@ function ufsc_render_club_list_page() {
         'ufsc-admin-style',
         UFSC_PLUGIN_URL . 'assets/css/admin.css',
         [],
-        UFSC_GESTION_CLUB_VERSION
+        UFSC_PLUGIN_VERSION
     );
     wp_enqueue_style(
 
@@ -62,7 +62,7 @@ function ufsc_render_club_list_page() {
         'https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js',
 
         [],
-        UFSC_GESTION_CLUB_VERSION
+        UFSC_PLUGIN_VERSION
     );
     wp_enqueue_script(
         'ufsc-admin-script',
@@ -72,7 +72,7 @@ function ufsc_render_club_list_page() {
 
         ['ufsc-datatables-config'],
 
-        UFSC_GESTION_CLUB_VERSION,
+        UFSC_PLUGIN_VERSION,
         true
     );
 

--- a/includes/frontend/club/club-infos.php
+++ b/includes/frontend/club/club-infos.php
@@ -29,7 +29,7 @@ function ufsc_club_render_profile($club)
         'ufsc-club-infos-compact',
         UFSC_PLUGIN_URL . 'assets/css/club-infos-compact.css',
         ['ufsc-theme'],
-        UFSC_GESTION_CLUB_VERSION
+        UFSC_PLUGIN_VERSION
     );
     
     // Security check: ensure we have a valid club object

--- a/includes/frontend/shortcodes/ajouter-licencie-shortcode.php
+++ b/includes/frontend/shortcodes/ajouter-licencie-shortcode.php
@@ -193,7 +193,7 @@ function ufsc_enqueue_add_licencie_assets()
         'ufsc-add-licencie',
         UFSC_PLUGIN_URL . 'assets/js/ufsc-add-licencie.js',
         ['jquery'],
-        UFSC_GESTION_CLUB_VERSION,
+        UFSC_PLUGIN_VERSION,
         true
     );
     

--- a/includes/frontend/shortcodes/dashboard-mvp-broken.php
+++ b/includes/frontend/shortcodes/dashboard-mvp-broken.php
@@ -421,7 +421,7 @@ function ufsc_enqueue_dashboard_mvp_assets() {
             'ufsc-club-logo',
             UFSC_PLUGIN_URL . 'assets/js/ufsc-club-logo.js',
             ['jquery'],
-            UFSC_GESTION_CLUB_VERSION,
+            UFSC_PLUGIN_VERSION,
             true
         );
         
@@ -438,6 +438,6 @@ function ufsc_enqueue_dashboard_mvp_assets() {
         'ufsc-dashboard-mvp',
         UFSC_PLUGIN_URL . 'assets/css/dashboard-mvp.css',
         [],
-        UFSC_GESTION_CLUB_VERSION
+        UFSC_PLUGIN_VERSION
     );
 }

--- a/includes/frontend/shortcodes/dashboard-mvp.php
+++ b/includes/frontend/shortcodes/dashboard-mvp.php
@@ -433,7 +433,7 @@ function ufsc_enqueue_dashboard_mvp_assets() {
             'ufsc-club-logo',
             UFSC_PLUGIN_URL . 'assets/js/ufsc-club-logo.js',
             ['jquery'],
-            UFSC_GESTION_CLUB_VERSION,
+            UFSC_PLUGIN_VERSION,
             true
         );
         
@@ -450,6 +450,6 @@ function ufsc_enqueue_dashboard_mvp_assets() {
         'ufsc-dashboard-mvp',
         UFSC_PLUGIN_URL . 'assets/css/dashboard-mvp.css',
         [],
-        UFSC_GESTION_CLUB_VERSION
+        UFSC_PLUGIN_VERSION
     );
 }

--- a/includes/frontend/shortcodes/order-history.php
+++ b/includes/frontend/shortcodes/order-history.php
@@ -32,7 +32,7 @@ function ufsc_order_history_shortcode($atts = array()) {
                 'ufsc-order-history',
                 UFSC_PLUGIN_URL . 'assets/css/order-history.css',
                 array(),
-                UFSC_GESTION_CLUB_VERSION
+                UFSC_PLUGIN_VERSION
             );
         }
 

--- a/includes/licences/admin-licence-edit.php
+++ b/includes/licences/admin-licence-edit.php
@@ -83,14 +83,14 @@ wp_enqueue_style(
     'ufsc-licence-form-style',
     UFSC_PLUGIN_URL . 'assets/css/form-licence.css',
     [],
-    UFSC_GESTION_CLUB_VERSION
+    UFSC_PLUGIN_VERSION
 );
 
 wp_enqueue_script(
     'ufsc-licence-form-script',
     UFSC_PLUGIN_URL . 'assets/js/form-licence.js',
     ['jquery'],
-    UFSC_GESTION_CLUB_VERSION,
+    UFSC_PLUGIN_VERSION,
     true
 );
 ?>

--- a/includes/licences/admin-licence-form.php
+++ b/includes/licences/admin-licence-form.php
@@ -145,14 +145,14 @@ wp_enqueue_style(
     'ufsc-licence-form-style',
     UFSC_PLUGIN_URL . 'assets/css/form-licence.css',
     [],
-    UFSC_GESTION_CLUB_VERSION
+    UFSC_PLUGIN_VERSION
 );
 
 wp_enqueue_script(
     'ufsc-licence-form-script',
     UFSC_PLUGIN_URL . 'assets/js/form-licence.js',
     ['jquery'],
-    UFSC_GESTION_CLUB_VERSION,
+    UFSC_PLUGIN_VERSION,
     true
 );
 ?>

--- a/includes/licences/admin-licence-list.php
+++ b/includes/licences/admin-licence-list.php
@@ -19,7 +19,7 @@ wp_enqueue_style(
     'ufsc-admin-licence-table-style',
     UFSC_PLUGIN_URL . 'assets/css/admin-licence-table.css',
     [],
-    UFSC_GESTION_CLUB_VERSION
+    UFSC_PLUGIN_VERSION
 );
 
 
@@ -86,7 +86,7 @@ wp_enqueue_script(
     'ufsc-datatables-config',
     UFSC_PLUGIN_URL . 'assets/js/datatables-config.js',
     ['datatables-js', 'datatables-buttons-js', 'datatables-responsive-js'],
-    UFSC_GESTION_CLUB_VERSION,
+    UFSC_PLUGIN_VERSION,
     true
 );
 

--- a/includes/shortcodes-attestations.php
+++ b/includes/shortcodes-attestations.php
@@ -33,7 +33,7 @@ function ufsc_attestations_enqueue_frontend_assets() {
         'ufsc-attestations-frontend',
         UFSC_PLUGIN_URL . 'assets/css/attestations-frontend.css',
         ['ufsc-frontend-style'],
-        UFSC_GESTION_CLUB_VERSION
+        UFSC_PLUGIN_VERSION
     );
     
     // Enqueue JS
@@ -41,7 +41,7 @@ function ufsc_attestations_enqueue_frontend_assets() {
         'ufsc-attestations-frontend',
         UFSC_PLUGIN_URL . 'assets/js/attestations-frontend.js',
         ['jquery'],
-        UFSC_GESTION_CLUB_VERSION,
+        UFSC_PLUGIN_VERSION,
         true
     );
     


### PR DESCRIPTION
## Summary
- set WordPress and PHP requirements to 6.6 and 8.3
- remove redundant version constant and use UFSC_PLUGIN_VERSION everywhere
- ensure all modules use unified 20.8.1 version

## Testing
- `php -l Plugin_UFSC_GESTION_CLUB_13072025.php`
- `for file in includes/shortcodes-attestations.php includes/frontend/shortcodes/order-history.php includes/frontend/shortcodes/dashboard-mvp-broken.php includes/frontend/shortcodes/ajouter-licencie-shortcode.php includes/admin/class-frontend-pro-settings.php includes/frontend/shortcodes/dashboard-mvp.php includes/admin/class-menu.php includes/admin/class-ufsc-admin-settings.php includes/admin/class-test-helper.php includes/frontend/club/club-infos.php includes/licences/admin-licence-form.php includes/licences/admin-licence-list.php includes/clubs/admin-club-list-page.php includes/licences/admin-licence-edit.php; do php -l $file >/tmp/lint.log && tail -n 1 /tmp/lint.log; done`
- `npm run build` *(fails: Invalid value for option "output.inlineDynamicImports" - multiple inputs are not supported when "output.inlineDynamicImports" is true.)*

------
https://chatgpt.com/codex/tasks/task_e_68ae53f7bdd0832ba320eec2785a9754