### PR TITLE
Fix WooCommerce integration conditional includes

### DIFF
--- a/Plugin_UFSC_GESTION_CLUB_13072025.php
+++ b/Plugin_UFSC_GESTION_CLUB_13072025.php
@@ -153,7 +153,11 @@ require_once UFSC_PLUGIN_PATH . 'includes/frontend/dashboard/overview.php';
 // New WooCommerce integration class (consolidated)
 if (file_exists(UFSC_PLUGIN_PATH . 'includes/class-ufsc-woocommerce-integration.php')) {
     require_once UFSC_PLUGIN_PATH . 'includes/class-ufsc-woocommerce-integration.php';
-require_once UFSC_PLUGIN_PATH . 'includes/woocommerce/cart-item-role-meta.php';
+}
+
+// Load cart item role metadata handling
+if (file_exists(UFSC_PLUGIN_PATH . 'includes/woocommerce/cart-item-role-meta.php')) {
+    require_once UFSC_PLUGIN_PATH . 'includes/woocommerce/cart-item-role-meta.php';
 }
 
 // New WooCommerce e-commerce features


### PR DESCRIPTION
## Summary
- Close WooCommerce integration conditional block and load `class-ufsc-woocommerce-integration.php` only when available
- Load `cart-item-role-meta.php` in its own existence-checked block

## Testing
- `php -l Plugin_UFSC_GESTION_CLUB_13072025.php`
- `phpunit` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae53fa43c0832bb0f1e148c9722ec0