### PR TITLE
Secure licence draft deletion

### DIFF
--- a/includes/frontend/ajax/licence-drafts.php
+++ b/includes/frontend/ajax/licence-drafts.php
@@ -130,4 +130,3 @@ function ufsc_ajax_delete_draft(){
     }
 }
 add_action('wp_ajax_ufsc_delete_licence_draft','ufsc_ajax_delete_draft');
-add_action('wp_ajax_nopriv_ufsc_delete_licence_draft','ufsc_ajax_delete_draft');


### PR DESCRIPTION
## Summary
- restrict licence draft deletion to logged-in club members
- drop nopriv AJAX hook for deleting licence drafts

## Testing
- `phpunit --testsuite core` *(fails: phpunit command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae53fb7838832bac62852a93243da2