### PR TITLE
feat(forms): add fieldsets and legends for accessibility

### DIFF
--- a/includes/clubs/form-club.php
+++ b/includes/clubs/form-club.php
@@ -341,10 +341,8 @@ function ufsc_render_club_form($club_id = 0, $is_frontend = false, $is_affiliati
             </div>
             
             <!-- Informations générales -->
-            <div class="ufsc-form-section">
-                <div class="ufsc-form-section-header">
-                    <i class="dashicons dashicons-groups"></i> Informations générales
-                </div>
+            <fieldset class="ufsc-form-section">
+                <legend><i class="dashicons dashicons-groups"></i> Informations générales</legend>
                 <div class="ufsc-form-section-description">
                     <p>Renseignez les informations de base de votre club ou association, incluant l'adresse de correspondance officielle.</p>
                 </div>
@@ -425,13 +423,11 @@ function ufsc_render_club_form($club_id = 0, $is_frontend = false, $is_affiliati
                         </div>
                     </div>
                 </div>
-            </div>
+            </fieldset>
 
             <!-- Section Photo/Logo et informations complémentaires -->
-            <div class="ufsc-form-section">
-                <div class="ufsc-form-section-header">
-                    <i class="dashicons dashicons-format-image"></i> Logo et Présence Web
-                </div>
+            <fieldset class="ufsc-form-section">
+                <legend><i class="dashicons dashicons-format-image"></i> Logo et Présence Web</legend>
                 <div class="ufsc-form-section-description">
                     <p>Personnalisez l'identité visuelle de votre club et renseignez vos canaux de communication.</p>
                 </div>
@@ -474,13 +470,11 @@ function ufsc_render_club_form($club_id = 0, $is_frontend = false, $is_affiliati
                         </div>
                     </div>
                 </div>
-            </div>
+            </fieldset>
 
             <!-- Section Informations légales et financières -->
-            <div class="ufsc-form-section">
-                <div class="ufsc-form-section-header">
-                    <i class="dashicons dashicons-admin-page"></i> Informations Légales et Financières
-                </div>
+            <fieldset class="ufsc-form-section">
+                <legend><i class="dashicons dashicons-admin-page"></i> Informations Légales et Financières</legend>
                 <div class="ufsc-form-section-description">
                     <p>Informations juridiques et bancaires nécessaires pour les clubs et associations.</p>
                 </div>
@@ -509,14 +503,12 @@ function ufsc_render_club_form($club_id = 0, $is_frontend = false, $is_affiliati
                         </div>
                     </div>
                 </div>
-            </div>
+            </fieldset>
 
             <!-- Section Administration (seulement en backend) -->
             <?php if (!$is_frontend): ?>
-            <div class="ufsc-form-section">
-                <div class="ufsc-form-section-header">
-                    <i class="dashicons dashicons-admin-tools"></i> Administration
-                </div>
+            <fieldset class="ufsc-form-section">
+                <legend><i class="dashicons dashicons-admin-tools"></i> Administration</legend>
                 <div class="ufsc-form-section-body">
                     <div class="ufsc-form-row">
                         <label for="statut">Statut du club</label>
@@ -586,36 +578,36 @@ function ufsc_render_club_form($club_id = 0, $is_frontend = false, $is_affiliati
                         </div>
                     </div>
                 </div>
-            </div>
+            </fieldset>
             <?php endif; ?>
                     
                     <?php if ($is_frontend && $is_affiliation && !$is_edit): ?>
                     <!-- Frontend User Association for Affiliation -->
                     <div class="ufsc-form-row">
-                        <label>Utilisateur WordPress pour gérer le club</label>
+                        <span class="ufsc-group-label">Utilisateur WordPress pour gérer le club</span>
                         <div>
                             <div class="ufsc-user-association-options">
                                 <div class="ufsc-radio-group">
-                                    <label class="ufsc-radio-option">
-                                        <input type="radio" name="user_association_type" value="current" checked>
-                                        <span>Utiliser mon compte actuel</span>
+                                    <div class="ufsc-radio-option">
+                                        <input type="radio" id="user_association_type_current" name="user_association_type" value="current" checked>
+                                        <label for="user_association_type_current">Utiliser mon compte actuel</label>
                                         <?php if (is_user_logged_in()): ?>
                                             <?php $current_user = wp_get_current_user(); ?>
                                             <div class="ufsc-form-hint">
                                                 Compte: <?php echo esc_html($current_user->display_name . ' (' . $current_user->user_login . ')'); ?>
                                             </div>
                                         <?php endif; ?>
-                                    </label>
-                                    
-                                    <label class="ufsc-radio-option">
-                                        <input type="radio" name="user_association_type" value="create">
-                                        <span>Créer un nouveau compte utilisateur</span>
-                                    </label>
-                                    
-                                    <label class="ufsc-radio-option">
-                                        <input type="radio" name="user_association_type" value="existing">
-                                        <span>Associer un compte existant</span>
-                                    </label>
+                                    </div>
+
+                                    <div class="ufsc-radio-option">
+                                        <input type="radio" id="user_association_type_create" name="user_association_type" value="create">
+                                        <label for="user_association_type_create">Créer un nouveau compte utilisateur</label>
+                                    </div>
+
+                                    <div class="ufsc-radio-option">
+                                        <input type="radio" id="user_association_type_existing" name="user_association_type" value="existing">
+                                        <label for="user_association_type_existing">Associer un compte existant</label>
+                                    </div>
                                 </div>
                                 
                                 <!-- Create new user fields -->
@@ -672,10 +664,8 @@ function ufsc_render_club_form($club_id = 0, $is_frontend = false, $is_affiliati
             </div>
             
             <!-- Informations légales -->
-            <div class="ufsc-form-section">
-                <div class="ufsc-form-section-header">
-                    <i class="dashicons dashicons-clipboard"></i> Informations légales
-                </div>
+            <fieldset class="ufsc-form-section">
+                <legend><i class="dashicons dashicons-clipboard"></i> Informations légales</legend>
                 <div class="ufsc-form-section-description">
                     <p>Informations administratives et légales de votre structure.</p>
                 </div>
@@ -722,14 +712,14 @@ function ufsc_render_club_form($club_id = 0, $is_frontend = false, $is_affiliati
                         </div>
                     </div>
                 </div>
-            </div>
+            </fieldset>
             
             <!-- Dirigeants -->
-            <div class="ufsc-form-section">
-                <div class="ufsc-form-section-header">
+            <fieldset class="ufsc-form-section">
+                <legend>
                     <i class="dashicons dashicons-businessperson"></i> Dirigeants
                     <span class="ufsc-badge ufsc-badge-featured">Champs obligatoires</span>
-                </div>
+                </legend>
                 <div class="ufsc-form-section-description">
                     <p>Informations des dirigeants du club. Ces personnes recevront automatiquement une licence dirigeant lors de l'affiliation.</p>
                 </div>
@@ -786,16 +776,16 @@ function ufsc_render_club_form($club_id = 0, $is_frontend = false, $is_affiliati
                         <?php endif; ?>
                     <?php endforeach; ?>
                 </div>
-            </div>
+            </fieldset>
             
             <!-- Documents administratifs -->
-            <div class="ufsc-form-section">
-                <div class="ufsc-form-section-header">
+            <fieldset class="ufsc-form-section">
+                <legend>
                     <i class="dashicons dashicons-media-document"></i> Documents administratifs
                     <?php if ($is_affiliation): ?>
                     <span class="ufsc-badge ufsc-badge-featured">Obligatoire pour l'affiliation</span>
                     <?php endif; ?>
-                </div>
+                </legend>
                 <div class="ufsc-form-section-description">
                     <p>Téléchargez les documents administratifs requis pour votre club.</p>
                     <p><strong>Formats acceptés :</strong> PDF, JPG, PNG. <strong>Taille max :</strong> 5 Mo par document.</p>
@@ -818,7 +808,7 @@ function ufsc_render_club_form($club_id = 0, $is_frontend = false, $is_affiliati
                         </div>
                     <?php endforeach; ?>
                 </div>
-            </div>
+            </fieldset>
             
             <!-- Bouton de soumission -->
             <div class="ufsc-form-row" style="justify-content: flex-end; margin-top: 30px;">

--- a/includes/frontend/forms/affiliation-form-render.php
+++ b/includes/frontend/forms/affiliation-form-render.php
@@ -116,8 +116,8 @@ function ufsc_render_affiliation_form($args = [])
     }
     
     // Club information section
-    $output .= '<div class="ufsc-form-section">
-        <h4>Informations du club</h4>
+    $output .= '<fieldset class="ufsc-form-section">
+        <legend>Informations du club</legend>
         <div class="ufsc-form-field">
             <label for="nom">Nom du club *</label>
             <input type="text" id="nom" name="nom" required maxlength="200" value="' . ($existing_club ? esc_attr($existing_club->nom) : '') . '">
@@ -175,11 +175,11 @@ function ufsc_render_affiliation_form($args = [])
         </div>';
     }
     
-    $output .= '</div>';
+    $output .= '</fieldset>';
     
     // Contact information section
-    $output .= '<div class="ufsc-form-section">
-        <h4>Contact</h4>
+    $output .= '<fieldset class="ufsc-form-section">
+        <legend>Contact</legend>
         <div class="ufsc-form-grid">
             <div class="ufsc-form-field">
                 <label for="email">Email *</label>
@@ -201,11 +201,11 @@ function ufsc_render_affiliation_form($args = [])
             <p class="ufsc-form-hint"></p>
             <span class="ufsc-form-error"></span>
         </div>
-    </div>';
+    </fieldset>';
     
     // Additional information section
-    $output .= '<div class="ufsc-form-section">
-        <h4>Informations complémentaires</h4>
+    $output .= '<fieldset class="ufsc-form-section">
+        <legend>Informations complémentaires</legend>
         <div class="ufsc-form-grid">
             <div class="ufsc-form-field">
                 <label for="siret">SIRET</label>
@@ -227,10 +227,11 @@ function ufsc_render_affiliation_form($args = [])
             <p class="ufsc-form-hint"></p>
             <span class="ufsc-form-error"></span>
         </div>
-    </div>';
+    </fieldset>';
     
     // Terms and conditions
-    $output .= '<div class="ufsc-form-section">
+    $output .= '<fieldset class="ufsc-form-section">
+        <legend>Conditions et consentements</legend>
         <div class="ufsc-form-field">
             <label for="accept_terms">J\'accepte les <a href="#" target="_blank">conditions générales</a> et le <a href="#" target="_blank">règlement intérieur</a> de l\'UFSC *</label>
             <input type="checkbox" id="accept_terms" name="accept_terms" required>
@@ -244,7 +245,7 @@ function ufsc_render_affiliation_form($args = [])
             <p class="ufsc-form-hint"></p>
             <span class="ufsc-form-error"></span>
         </div>
-    </div>';
+    </fieldset>';
     
     // Form actions
     $output .= '<div class="ufsc-form-actions">

--- a/includes/frontend/forms/licence-form-render.php
+++ b/includes/frontend/forms/licence-form-render.php
@@ -67,8 +67,8 @@ function ufsc_render_licence_form($args = array()){
         <input type="hidden" name="licence_id" value="<?php echo esc_attr($prefill['id']); ?>">
       <?php endif; ?>
 
-      <div class="ufsc-form-section">
-        <h4>Informations personnelles</h4>
+      <fieldset class="ufsc-form-section">
+        <legend>Informations personnelles</legend>
         <div class="ufsc-form-grid">
           <div class="ufsc-form-field">
             <label for="nom">Nom *</label>
@@ -109,10 +109,10 @@ function ufsc_render_licence_form($args = array()){
           <p class="ufsc-form-hint"></p>
           <span class="ufsc-form-error"></span>
         </div>
-      </div>
+      </fieldset>
 
-      <div class="ufsc-form-section">
-        <h4>Coordonnées</h4>
+      <fieldset class="ufsc-form-section">
+        <legend>Coordonnées</legend>
         <div class="ufsc-form-field">
           <label for="adresse">Adresse</label>
           <input type="text" id="adresse" name="adresse" maxlength="200" value="<?php echo $v('adresse'); ?>">
@@ -153,10 +153,10 @@ function ufsc_render_licence_form($args = array()){
             <span class="ufsc-form-error"></span>
           </div>
         </div>
-      </div>
+      </fieldset>
 
-      <div class="ufsc-form-section">
-        <h4>Rôle & type</h4>
+      <fieldset class="ufsc-form-section">
+        <legend>Rôle & type</legend>
         <div class="ufsc-form-grid">
           <div class="ufsc-form-field">
             <label for="fonction">Fonction</label>
@@ -192,10 +192,10 @@ function ufsc_render_licence_form($args = array()){
             <span class="ufsc-form-error"></span>
           </div>
       </div>
-      </div>
+      </fieldset>
 
-      <div class="ufsc-form-section">
-        <h4>Autorisations et communications</h4>
+      <fieldset class="ufsc-form-section">
+        <legend>Autorisations et communications</legend>
         <div class="ufsc-form-grid">
           <div class="ufsc-form-field">
             <label for="diffusion_image">Consentement diffusion image</label>
@@ -228,10 +228,10 @@ function ufsc_render_licence_form($args = array()){
             <span class="ufsc-form-error"></span>
           </div>
         </div>
-      </div>
+      </fieldset>
 
-      <div class="ufsc-form-section">
-        <h4>Déclarations et assurances</h4>
+      <fieldset class="ufsc-form-section">
+        <legend>Déclarations et assurances</legend>
         <div class="ufsc-form-grid">
           <div class="ufsc-form-field">
             <label for="honorabilite">Déclaration d'honorabilité</label>
@@ -252,16 +252,17 @@ function ufsc_render_licence_form($args = array()){
             <span class="ufsc-form-error"></span>
           </div>
         </div>
-      </div>
+      </fieldset>
 
-      <div class="ufsc-form-section">
+      <fieldset class="ufsc-form-section">
+        <legend>Règlements</legend>
         <div class="ufsc-form-field">
           <label for="ufsc_rules_ack">J'ai pris connaissance des règlements — <a href="https://ufsc-france.fr/ufsc-reglements-sportifs-techniques-interieur/" target="_blank" rel="noopener">Lire les règlements</a></label>
           <input type="checkbox" id="ufsc_rules_ack" name="ufsc_rules_ack" value="1" required>
           <p class="ufsc-form-hint"></p>
           <span class="ufsc-form-error"></span>
         </div>
-      </div>
+      </fieldset>
 
       <div class="ufsc-form-actions">
         <button type="button" id="ufsc-save-draft" class="ufsc-btn ufsc-btn-secondary">💾 Enregistrer brouillon</button>


### PR DESCRIPTION
## Summary
- wrap form sections in `<fieldset>` with descriptive `<legend>`
- ensure each `<label>` is associated with its input via `for`
- update frontend forms to match fieldset pattern for WCAG 2.1 AA

## Testing
- `npm test` *(fails: Missing script "test")*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae5328d540832b9cb8d367cc9df268