### PR TITLE
chore: align PHP requirement to 8.2

### DIFF
--- a/Plugin_UFSC_GESTION_CLUB_13072025.php
+++ b/Plugin_UFSC_GESTION_CLUB_13072025.php
@@ -14,7 +14,7 @@ if (!defined('UFSC_ENABLE_DIAG_ENDPOINT')) define('UFSC_ENABLE_DIAG_ENDPOINT', f
  * Domain Path: /languages
  * Requires at least: 6.6
  * Tested up to: 6.8
- * Requires PHP: 8.3
+ * Requires PHP: 8.2
  * Network: false
  */
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: studioreactiv
 Tags: club, management, affiliation, license, ufsc
 Requires at least: 5.5
 Tested up to: 6.8
-Requires PHP: 7.4
+Requires PHP: 8.2
 Stable tag: 1.2.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
## Summary
- lower plugin PHP requirement to 8.2
- update readme to reflect PHP 8.2

## Testing
- `php -l Plugin_UFSC_GESTION_CLUB_13072025.php`
- `mise install php@8.2` *(fails: CONNECT tunnel failed, response 403)*
- `curl -L https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar -o wp-cli.phar` *(fails: CONNECT tunnel failed, response 403)*


------
https://chatgpt.com/codex/tasks/task_e_68ae6202af98832bb99d3cb669793ea5