### PR TITLE
Use helper to resolve club id in licence list

### DIFF
--- a/includes/frontend/parts/licence-list.php
+++ b/includes/frontend/parts/licence-list.php
@@ -5,7 +5,10 @@ if (!defined('ABSPATH')) {
 
 global $wpdb;
 
-$club_id = get_user_meta(get_current_user_id(), 'ufsc_club_id', true);
+if (!function_exists('ufscx_resolve_club_id')) {
+    require_once dirname(__DIR__) . '/shortcodes/licenses-direct.php';
+}
+$club_id = ufscx_resolve_club_id();
 if (!$club_id) {
     echo '<p>🔒 Accès refusé. Club introuvable.</p>';
     return;


### PR DESCRIPTION
## Summary
- use `ufscx_resolve_club_id()` to determine current club in licence list
- load resolver function if missing to support alternate meta keys

## Testing
- `php -l includes/frontend/parts/licence-list.php`
- `phpunit` *(fails: command not found)*
- `npm test` *(fails: missing script: test)*

------
https://chatgpt.com/codex/tasks/task_e_68ae706b964c832ba7c21959334e1dde