### PR TITLE
Enforce licence permissions in AJAX handlers

### DIFF
--- a/includes/helpers/club-permissions.php
+++ b/includes/helpers/club-permissions.php
@@ -1,0 +1,33 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+if (!function_exists('ufscsn_resolve_club_id_sanitized')) {
+    function ufscsn_resolve_club_id_sanitized(): int {
+        $source = $_REQUEST['club_id'] ?? 0;
+        return $source ? absint(wp_unslash($source)) : 0;
+    }
+}
+
+if (!function_exists('ufscsn_require_manage_licence')) {
+    function ufscsn_require_manage_licence(int $licence_id) {
+        if (!current_user_can('manage_ufsc_licences')) {
+            wp_send_json_error(__('Access denied.', 'plugin-ufsc-gestion-club-13072025'), 403);
+        }
+
+        $club_id = ufscsn_resolve_club_id_sanitized();
+        if (!$club_id) {
+            wp_send_json_error(__('Club ID missing.', 'plugin-ufsc-gestion-club-13072025'), 403);
+        }
+
+        require_once UFSC_PLUGIN_PATH . 'includes/licences/class-licence-manager.php';
+        $licence_manager = new UFSC_Licence_Manager();
+        $licence = $licence_manager->get_licence_by_id($licence_id);
+        if (!$licence || intval($licence->club_id) !== intval($club_id)) {
+            wp_send_json_error(__('Club mismatch.', 'plugin-ufsc-gestion-club-13072025'), 403);
+        }
+
+        return $licence;
+    }
+}


### PR DESCRIPTION
## Summary
- add shared permission helper ensuring club ownership
- validate permissions after nonce for licence and club attestation actions
- verify licence club matches current club before updates

## Testing
- `php -l Plugin_UFSC_GESTION_CLUB_13072025.php`
- `php -l includes/helpers/club-permissions.php`
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae74086634832bbdf1d104108ec142