### PR TITLE
Refactor front AJAX handlers for JSON messages

### DIFF
--- a/assets/js/ufsc-front-profix.js
+++ b/assets/js/ufsc-front-profix.js
@@ -3,8 +3,8 @@ var ajaxUrl=(UFSC_PRO&&UFSC_PRO.ajaxUrl)||'/wp-admin/admin-ajax.php';var nonce=(
 function toast(m){var t=$('<div class="ufsc-toast"></div>').text(m).appendTo('body');setTimeout(function(){t.fadeOut(150,function(){t.remove();});},1300);} 
 $('<style>').text('.ufsc-toast{position:fixed;right:16px;top:16px;background:#111;color:#fff;padding:8px 12px;border-radius:10px;z-index:99999;opacity:.95}').appendTo(document.head);
 function post(a,d){d=d||{};d.action=a;if(nonce)d._ajax_nonce=nonce;return $.post(ajaxUrl,d);}
-$(document).on('click','.ufsc-pay-licence,.ufsc-add-to-cart',function(e){e.preventDefault();var $b=$(this),id=$b.data('licenceId')||$b.data('licence-id');if(!id)return;$b.prop('disabled',true);post('ufsc_add_to_cart',{licence_id:id}).done(function(r){if(r&&r.success&&r.data&&r.data.redirect){window.location.href=r.data.redirect;}else{toast((r&&r.data)||'Erreur');}}).fail(function(){toast('Erreur réseau');}).always(function(){$b.prop('disabled',false);});});
-$(document).on('click','.ufsc-delete-draft',function(e){e.preventDefault();var $b=$(this),id=$b.data('licenceId')||$b.data('licence-id');if(!id)return;if(!confirm('Supprimer ce brouillon ?'))return;$b.prop('disabled',true);post('ufsc_delete_licence_draft',{licence_id:id}).done(function(r){if(r&&r.success){location.reload();}else{toast((r&&r.data)||'Erreur');}}).fail(function(){toast('Erreur réseau');}).always(function(){$b.prop('disabled',false);});});
+$(document).on('click','.ufsc-pay-licence,.ufsc-add-to-cart',function(e){e.preventDefault();var $b=$(this),id=$b.data('licenceId')||$b.data('licence-id');if(!id)return;$b.prop('disabled',true);post('ufsc_add_to_cart',{licence_id:id}).done(function(r){if(r&&r.success&&r.data&&r.data.redirect){window.location.href=r.data.redirect;}else{toast((r&&r.data&&r.data.message)||'Erreur');}}).fail(function(){toast('Erreur réseau');}).always(function(){$b.prop('disabled',false);});});
+$(document).on('click','.ufsc-delete-draft',function(e){e.preventDefault();var $b=$(this),id=$b.data('licenceId')||$b.data('licence-id');if(!id)return;if(!confirm('Supprimer ce brouillon ?'))return;$b.prop('disabled',true);post('ufsc_delete_licence_draft',{licence_id:id}).done(function(r){if(r&&r.success){location.reload();}else{toast((r&&r.data&&r.data.message)||'Erreur');}}).fail(function(){toast('Erreur réseau');}).always(function(){$b.prop('disabled',false);});});
 
 $(document).on('click','.ufsc-include-quota',function(e){
   e.preventDefault();
@@ -12,8 +12,8 @@ $(document).on('click','.ufsc-include-quota',function(e){
   $b.prop('disabled',true);
   post('ufsc_include_quota',{licence_id:id}).done(function(r){
     if(r&&r.success){ toast('Inclus au quota'); location.reload(); }
-    else { alert((r&&r.data)?r.data:'Inclusion impossible'); }
-  }).fail(function(){ alert('Erreur réseau'); }).always(function(){ $b.prop('disabled',false); });
+    else { toast((r&&r.data&&r.data.message)||'Inclusion impossible'); }
+  }).fail(function(){ toast('Erreur réseau'); }).always(function(){ $b.prop('disabled',false); });
 });
 
 })(jQuery);

--- a/includes/frontend/ajax/quota.php
+++ b/includes/frontend/ajax/quota.php
@@ -3,20 +3,28 @@ if (!defined('ABSPATH')) exit;
 
 add_action('wp_ajax_ufsc_include_quota', 'ufsc_ajax_include_quota');
 function ufsc_ajax_include_quota(){
-    if (!ufsc_check_ajax_nonce('ufsc_front_nonce', '_ajax_nonce', false)) wp_send_json_error('Bad nonce',403);
-    if (!is_user_logged_in()) wp_send_json_error('Non connecté',401);
+    if (!ufsc_check_ajax_nonce('ufsc_front_nonce', '_ajax_nonce', false)) {
+        wp_send_json_error(['message' => 'Bad nonce'],403);
+    }
+    if (!is_user_logged_in()) {
+        wp_send_json_error(['message' => 'Non connecté'],401);
+    }
 
     $licence_id = isset($_POST['licence_id']) ? absint($_POST['licence_id']) : 0;
     $season = isset($_POST['season']) ? sanitize_text_field($_POST['season']) : date('Y');
     $uid = get_current_user_id();
     $club_id = (int) get_user_meta($uid, 'ufsc_club_id', true);
-    if (!$licence_id || !$club_id) wp_send_json_error('Données manquantes');
+    if (!$licence_id || !$club_id) {
+        wp_send_json_error(['message' => 'Données manquantes']);
+    }
 
     global $wpdb; $t = $wpdb->prefix.'ufsc_licences';
     // Option simple quota: ufsc_quota_{club}_{season}_allowed
     $allowed = (int) get_option('ufsc_quota_'.$club_id.'_'.$season.'_allowed', 0);
     $used    = (int) $wpdb->get_var( $wpdb->prepare("SELECT COUNT(*) FROM {$t} WHERE club_id=%d AND season=%s AND billing_source='quota' AND statut='validee'", $club_id, $season) );
-    if ($allowed && $used >= $allowed) wp_send_json_error('Quota atteint');
+    if ($allowed && $used >= $allowed) {
+        wp_send_json_error(['message' => 'Quota atteint']);
+    }
 
     $ok = $wpdb->update($t, [
         'statut' => 'validee',
@@ -25,8 +33,10 @@ function ufsc_ajax_include_quota(){
     ], ['id'=>$licence_id, 'club_id'=>$club_id], ['%s','%s','%s'], ['%d','%d']);
 
     if ($ok !== false) {
-        if (function_exists('ufsc__log_status_change')) ufsc__log_status_change($licence_id, 'validee', $uid);
+        if (function_exists('ufsc__log_status_change')) {
+            ufsc__log_status_change($licence_id, 'validee', $uid);
+        }
         wp_send_json_success();
     }
-    wp_send_json_error('Échec inclusion quota');
+    wp_send_json_error(['message' => 'Échec inclusion quota']);
 }

--- a/includes/overrides_profix/ajax-actions.php
+++ b/includes/overrides_profix/ajax-actions.php
@@ -2,16 +2,22 @@
 if (!defined('ABSPATH')) exit;
 function ufsc_profix_ajax_add_to_cart(){
     check_ajax_referer('ufsc_front_nonce');
-    if (!class_exists('WC')) wp_send_json_error(__('WooCommerce requis','plugin-ufsc-gestion-club-13072025'),400);
+    if (!class_exists('WC')) {
+        wp_send_json_error(['message' => __('WooCommerce requis','plugin-ufsc-gestion-club-13072025')],400);
+    }
     $product_id = isset($_POST['product_id']) ? absint($_POST['product_id']) : 0;
     if (!$product_id) {
         // fallback to defined constant
         $product_id = defined('UFSC_LICENCE_PRODUCT_ID') ? (int)UFSC_LICENCE_PRODUCT_ID : 0;
     }
-    if (!$product_id) wp_send_json_error('product_id requis');
+    if (!$product_id) {
+        wp_send_json_error(['message' => 'product_id requis']);
+    }
     $qty = isset($_POST['quantity']) ? max(1, absint($_POST['quantity'])) : 1;
     $added = WC()->cart->add_to_cart($product_id, $qty);
-    if (!$added) wp_send_json_error('Ajout au panier impossible');
+    if (!$added) {
+        wp_send_json_error(['message' => 'Ajout au panier impossible']);
+    }
     $data = [
         'redirect' => function_exists('wc_get_cart_url') ? wc_get_cart_url() : home_url('/panier/')
     ];
@@ -22,16 +28,22 @@ add_action('wp_ajax_nopriv_ufsc_add_to_cart','ufsc_profix_ajax_add_to_cart');
 
 function ufsc_profix_ajax_save_draft(){
     check_ajax_referer('ufsc_front_nonce');
-    if (!is_user_logged_in()) wp_send_json_error('Connexion requise');
+    if (!is_user_logged_in()) {
+        wp_send_json_error(['message' => 'Connexion requise']);
+    }
     global $wpdb; $table = $wpdb->prefix.'ufsc_licences';
     $club = function_exists('ufsc_get_user_club') ? ufsc_get_user_club() : null;
     $club_id = ($club && isset($club->id)) ? (int)$club->id : 0;
-    if (!$club_id) wp_send_json_error('Club introuvable');
+    if (!$club_id) {
+        wp_send_json_error(['message' => 'Club introuvable']);
+    }
     $nom = isset($_POST['nom']) ? sanitize_text_field(wp_unslash($_POST['nom'])) : '';
     $prenom = isset($_POST['prenom']) ? sanitize_text_field(wp_unslash($_POST['prenom'])) : '';
     $email = isset($_POST['email']) ? sanitize_email(wp_unslash($_POST['email'])) : '';
     $role = isset($_POST['role']) ? sanitize_text_field(wp_unslash($_POST['role'])) : '';
-    if ($nom===''||$prenom===''||$email==='') wp_send_json_error('Nom, prénom et email requis');
+    if ($nom===''||$prenom===''||$email==='') {
+        wp_send_json_error(['message' => 'Nom, prénom et email requis']);
+    }
     $licence_id = isset($_POST['licence_id']) ? absint($_POST['licence_id']) : 0;
     $now = current_time('mysql');
     if ($licence_id) {
@@ -41,15 +53,19 @@ function ufsc_profix_ajax_save_draft(){
             ['%s','%s','%s','%s','%s','%s'],
             ['%d','%d']
         );
-        if ($ok!==false) wp_send_json_success(['licence_id'=>$licence_id]);
-        wp_send_json_error('Échec de mise à jour du brouillon');
+        if ($ok!==false) {
+            wp_send_json_success(['licence_id'=>$licence_id]);
+        }
+        wp_send_json_error(['message' => 'Échec de mise à jour du brouillon']);
     } else {
         $ok = $wpdb->insert($table,
             ['club_id'=>$club_id,'role'=>$role,'nom'=>$nom,'prenom'=>$prenom,'email'=>$email,'statut'=>'brouillon','date_creation'=>$now],
             ['%d','%s','%s','%s','%s','%s','%s']
         );
-        if ($ok) wp_send_json_success(['licence_id'=>(int)$wpdb->insert_id]);
-        wp_send_json_error('Échec de création du brouillon');
+        if ($ok) {
+            wp_send_json_success(['licence_id'=>(int)$wpdb->insert_id]);
+        }
+        wp_send_json_error(['message' => 'Échec de création du brouillon']);
     }
 }
 add_action('wp_ajax_ufsc_save_licence_draft','ufsc_profix_ajax_save_draft');
@@ -57,22 +73,32 @@ add_action('wp_ajax_nopriv_ufsc_save_licence_draft','ufsc_profix_ajax_save_draft
 function ufsc_profix_ajax_delete_draft(){
     check_ajax_referer('ufsc_front_nonce');
     if ( ! is_user_logged_in() ) {
-        wp_send_json_error('Connexion requise');
+        wp_send_json_error(['message' => 'Connexion requise']);
     }
     global $wpdb;
     $id = isset($_POST['licence_id']) ? absint($_POST['licence_id']) : 0;
-    if ( ! $id ) wp_send_json_error('ID manquant');
+    if ( ! $id ) {
+        wp_send_json_error(['message' => 'ID manquant']);
+    }
     $club = function_exists('ufsc_get_user_club') ? ufsc_get_user_club() : null;
     $club_id = ($club && isset($club->id)) ? (int) $club->id : 0;
-    if ( ! $club_id ) wp_send_json_error('Club introuvable');
+    if ( ! $club_id ) {
+        wp_send_json_error(['message' => 'Club introuvable']);
+    }
     $table = $wpdb->prefix.'ufsc_licences';
     $licence = $wpdb->get_row($wpdb->prepare("SELECT club_id FROM $table WHERE id=%d", $id));
-    if ( ! $licence ) wp_send_json_error('Licence introuvable');
+    if ( ! $licence ) {
+        wp_send_json_error(['message' => 'Licence introuvable']);
+    }
     if ( (int) $licence->club_id !== $club_id ) {
-        wp_send_json_error('Utilisateur non autorisé');
+        wp_send_json_error(['message' => 'Utilisateur non autorisé']);
     }
     $ok = $wpdb->update($table, ['statut'=>'trash','deleted_at'=>current_time('mysql')], ['id'=>$id,'club_id'=>$club_id], ['%s','%s'], ['%d','%d']);
-    if ($ok!==false) { wp_send_json_success(); } else { wp_send_json_error('Suppression impossible'); }
+    if ($ok!==false) {
+        wp_send_json_success();
+    } else {
+        wp_send_json_error(['message' => 'Suppression impossible']);
+    }
 }
 add_action('wp_ajax_ufsc_delete_licence_draft','ufsc_profix_ajax_delete_draft');
 


### PR DESCRIPTION
## Summary
- Return structured JSON with `message` fields in front-end AJAX handlers
- Parse JSON error messages in front scripts and show toast notifications

## Testing
- `npm test` *(fails: Missing script "test")*
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `phpunit` *(fails: command not found)*
- `npm run build` *(fails: Invalid value for option "output.inlineDynamicImports")*


------
https://chatgpt.com/codex/tasks/task_e_68ae74090114832ba7f13ca47fd2248a