### PR TITLE
Disable editing for final licences

### DIFF
--- a/assets/js/ufsc-licenses-direct.js
+++ b/assets/js/ufsc-licenses-direct.js
@@ -55,6 +55,31 @@
     rows = rows.slice(0, per); // simple paginate (first page)
     tbody.innerHTML = rows.map(r=>{
       const status = normalizeStatus(r.statut);
+      const isFinal = ['validee','refusee','expiree'].includes(status);
+      const viewBtn = `<button class="ufscx-btn${isFinal?'':' ufscx-btn-soft'}" data-a="view" data-id="${r.id}">Voir</button>`;
+      const quotaBtn = `<button class="ufscx-btn" data-a="toggleq" data-id="${r.id}">${r.quota==='Oui'?'Retirer du quota':'Inclure au quota'}</button>`;
+
+      const actionBtns = (()=> {
+        if(isFinal) {
+          return `<button class="ufscx-btn ufscx-btn-soft" disabled title="Licence finalisée - modification impossible">Modifier</button>`;
+        }
+        if(status==='brouillon'){
+          return `
+            <button class="ufscx-btn ufscx-btn-soft" data-a="edit" data-id="${r.id}">Modifier</button>
+            <button class="ufscx-btn ufscx-btn-soft" data-a="delete" data-id="${r.id}">Supprimer</button>
+            <button class="ufscx-btn ufscx-btn-primary" data-a="pay" data-id="${r.id}">Envoyer au paiement</button>
+          `;
+        }
+        if(status==='in_cart'){
+          return `<button class="ufscx-btn ufscx-btn-soft" data-a="viewcart" data-id="${r.id}">Voir panier</button>`;
+        }
+        if(status==='pending_payment'){
+          return `<button class="ufscx-btn ufscx-btn-soft" data-a="vieworder" data-id="${r.id}">Voir commande</button>`;
+        }
+        // Default: allow edition for non-final statuses
+        return `<button class="ufscx-btn ufscx-btn-soft" data-a="edit" data-id="${r.id}">Modifier</button>`;
+      })();
+
       return `
       <tr class="ufscx-row">
         <td>${r.id}</td>
@@ -68,58 +93,11 @@
         <td>${r.quota||''}</td>
         <td><span class="ufscx-pill">${status}</span></td>
         <td>${fmtDate(r.date_licence)}</td>
-
-        <td>${(()=>{
-          const status = (r.statut||'').toLowerCase();
-          const isFinal = ['validee','refusee','expiree'].includes(status);
-          const buttons = [];
-          const viewBtn = `<button class="ufscx-btn${isFinal?'':' ufscx-btn-soft'}" data-a="view" data-id="${r.id}">Voir</button>`;
-          const quotaBtn = `<button class="ufscx-btn" data-a="toggleq" data-id="${r.id}">${r.quota==='Oui'?'Retirer du quota':'Inclure au quota'}</button>`;
-          if(status==='brouillon'){
-            buttons.push(`<button class="ufscx-btn ufscx-btn-soft" data-a="edit" data-id="${r.id}">Modifier</button>`);
-            buttons.push(`<button class="ufscx-btn ufscx-btn-soft" data-a="delete" data-id="${r.id}">Supprimer</button>`);
-            buttons.push(`<button class="ufscx-btn ufscx-btn-primary" data-a="pay" data-id="${r.id}">Envoyer au paiement</button>`);
-            if(!isFinal) buttons.push(quotaBtn);
-            buttons.push(viewBtn);
-          } else if(status==='in_cart'){
-            buttons.push(`<button class="ufscx-btn ufscx-btn-soft" data-a="viewcart" data-id="${r.id}">Voir panier</button>`);
-            if(!isFinal) buttons.push(quotaBtn);
-            buttons.push(viewBtn);
-          } else if(status==='pending_payment'){
-            buttons.push(`<button class="ufscx-btn ufscx-btn-soft" data-a="vieworder" data-id="${r.id}">Voir commande</button>`);
-            if(!isFinal) buttons.push(quotaBtn);
-            buttons.push(viewBtn);
-          } else {
-            buttons.push(viewBtn);
-            if(!isFinal) buttons.push(quotaBtn);
-
-
-        <td>
-          <button class="ufscx-btn${['validee','refusee','expiree'].includes(status)?'':' ufscx-btn-soft'}" data-a="view" data-id="${r.id}">Voir</button>
-          ${['validee','refusee','expiree'].includes(status)?'':`<button class="ufscx-btn" data-a="toggleq" data-id="${r.id}">${r.quota==='Oui'?'Retirer du quota':'Inclure au quota'}</button>`}
-        </td>
-
-        <td>${(()=>{
-          if(status==='brouillon'){
-            return `
-              <button class="ufscx-btn ufscx-btn-soft" data-a="edit" data-id="${r.id}">Modifier</button>
-              <button class="ufscx-btn ufscx-btn-soft" data-a="delete" data-id="${r.id}">Supprimer</button>
-              <button class="ufscx-btn ufscx-btn-primary" data-a="pay" data-id="${r.id}">Envoyer au paiement</button>
-              <button class="ufscx-btn" data-a="toggleq" data-id="${r.id}">${r.quota==='Oui'?'Retirer du quota':'Inclure au quota'}</button>
-            `;
-          }
-          if(status==='in_cart'){
-            return `<button class="ufscx-btn ufscx-btn-soft" data-a="viewcart" data-id="${r.id}">Voir panier</button>`;
-          }
-          if(status==='pending_payment'){
-            return `<button class="ufscx-btn ufscx-btn-soft" data-a="vieworder" data-id="${r.id}">Voir commande</button>`;
-
-          }
-          return buttons.join(' ');
-        })()}</td>
-
+        <td>${viewBtn} ${isFinal?'':quotaBtn}</td>
+        <td>${actionBtns}</td>
       </tr>
-    `;}).join('');
+      `;
+    }).join('');
   }
 
   $all('th.sort').forEach(th=>{


### PR DESCRIPTION
## Summary
- prevent editing for validated or otherwise finalised licences in direct list
- add tooltip and disabled state for final licences

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: Invalid value for option "output.inlineDynamicImports" - multiple inputs are not supported when "output.inlineDynamicImports" is true.)

------
https://chatgpt.com/codex/tasks/task_e_68ae7ba37f58832bb2d551b9dea51561