### PR TITLE
Enforce consistent ufsc_licences table usage

### DIFF
--- a/includes/class-ufsc-woocommerce-integration.php
+++ b/includes/class-ufsc-woocommerce-integration.php
@@ -309,14 +309,14 @@ class UFSC_WooCommerce_Integration {
                 // Last resort: update user/club meta
                 $user_id = $order->get_user_id();
                 if ($user_id) {
-                    $existing_licenses = get_user_meta($user_id, 'ufsc_licenses', true) ?: array();
+                    $existing_licenses = get_user_meta($user_id, 'ufsc_licences', true) ?: array();
                     $existing_licenses[] = array(
                         'club_id' => $club_id,
                         'license_data' => $license_data,
                         'order_id' => $order->get_id(),
                         'created' => current_time('mysql')
                     );
-                    update_user_meta($user_id, 'ufsc_licenses', $existing_licenses);
+                    update_user_meta($user_id, 'ufsc_licences', $existing_licenses);
                 }
             }
         }

--- a/includes/helpers/helpers-licence-status.php
+++ b/includes/helpers/helpers-licence-status.php
@@ -91,7 +91,7 @@ function ufsc_process_license_creation_after_payment($order_id)
     }
 
     // Check if already processed
-    if ($order->get_meta('ufsc_licenses_processed')) {
+    if ($order->get_meta('ufsc_licences_processed')) {
         return;
     }
 
@@ -133,7 +133,7 @@ function ufsc_process_license_creation_after_payment($order_id)
     }
 
     // Mark as processed
-    $order->add_meta_data('ufsc_licenses_processed', true);
+    $order->add_meta_data('ufsc_licences_processed', true);
     $order->save();
 }
 

--- a/includes/licences/persist.php
+++ b/includes/licences/persist.php
@@ -2,7 +2,7 @@
 if (!defined('ABSPATH')) exit;
 
 /**
- * Persist a licence from POST data into DB (ufsc_licences / ufsc_licenses).
+ * Persist a licence from POST data into DB (ufsc_licences).
  * Returns licence_id (int) on success or 0 on failure.
  *
  * @param int   $club_id
@@ -12,13 +12,7 @@ if (!defined('ABSPATH')) exit;
  */
 function ufsc_detect_licence_table_name(){
   global $wpdb;
-  $c1 = $wpdb->prefix.'ufsc_licences';
-  $c2 = $wpdb->prefix.'ufsc_licenses';
-  $exists = $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $c1));
-  if ($exists === $c1) return $c1;
-  $exists2 = $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $c2));
-  if ($exists2 === $c2) return $c2;
-  return $c1;
+  return $wpdb->prefix . 'ufsc_licences';
 }
 
 function ufsc_persist_licence_from_post($club_id, $licence_id = 0, $extra = array()){

--- a/includes/overrides/club-licenses-override.php
+++ b/includes/overrides/club-licenses-override.php
@@ -3,7 +3,7 @@ if (!defined('ABSPATH')) exit;
 
 /**
  * Robust override for the club licences page.
- * Works with tables: wp_ufsc_licences OR wp_ufsc_licenses
+ * Works with table: wp_ufsc_licences
  * Resolves club_id via ufsc_get_user_club(), mapping table fallback, or shortcode/GET override.
  */
 function ufsc_register_club_licences_override(){
@@ -17,13 +17,7 @@ add_action('init', 'ufsc_register_club_licences_override', 9999);
 
 function ufsc__detect_licence_table(){
     global $wpdb;
-    $candidates = array($wpdb->prefix.'ufsc_licences', $wpdb->prefix.'ufsc_licenses');
-    foreach ($candidates as $t){
-        $exists = $wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $t));
-        if ($exists === $t) return $t;
-    }
-    // fallback to the first name
-    return $candidates[0];
+    return $wpdb->prefix . 'ufsc_licences';
 }
 
 if (!function_exists('ufsc__resolve_club_id')) {


### PR DESCRIPTION
## Summary
- hardcode ufsc_licences table name in club override
- simplify licence persistence to use ufsc_licences only
- standardize metadata keys to use "licences"

## Testing
- `phpunit --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae86982f10832b8f67c6120e287746