### PR TITLE
Allow changing licence club from admin

### DIFF
--- a/includes/frontend/parts/form-licence.php
+++ b/includes/frontend/parts/form-licence.php
@@ -25,7 +25,7 @@ require_once plugin_dir_path(__FILE__) . '../../helpers.php';
             <!-- Club Selection -->
             <div class="ufsc-form-field">
                 <label for="club_id" class="required"><?php _e('Club', 'plugin-ufsc-gestion-club-13072025'); ?></label>
-                <select name="club_id" id="club_id" required <?php echo $current_licence ? 'disabled' : ''; ?>>
+                <select name="club_id" id="club_id" required <?php echo ($current_licence && !is_admin()) ? 'disabled' : ''; ?>>
                     <option value=""><?php _e('Sélectionner un club', 'plugin-ufsc-gestion-club-13072025'); ?></option>
                     <?php foreach ($clubs as $club): ?>
                         <option value="<?php echo esc_attr($club->id); ?>" <?php selected($current_club_id, $club->id); ?>>
@@ -33,7 +33,7 @@ require_once plugin_dir_path(__FILE__) . '../../helpers.php';
                         </option>
                     <?php endforeach; ?>
                 </select>
-                <?php if ($current_licence): ?>
+                <?php if ($current_licence && !is_admin()): ?>
                     <input type="hidden" name="club_id" value="<?php echo esc_attr($current_licence->club_id); ?>">
                     <span class="help-text"><?php _e('Le club ne peut pas être modifié après création', 'plugin-ufsc-gestion-club-13072025'); ?></span>
                 <?php endif; ?>

--- a/includes/licences/admin-licence-edit.php
+++ b/includes/licences/admin-licence-edit.php
@@ -43,6 +43,7 @@ if (!$club) {
 // 📝 Traitement de la modification de licence
 if (isset($_SERVER['REQUEST_METHOD']) && $_SERVER['REQUEST_METHOD'] === 'POST' && check_admin_referer('ufsc_edit_licence', 'ufsc_edit_licence_nonce')) {
     $data = [
+        'club_id'                     => isset($_POST['club_id']) ? intval($_POST['club_id']) : $current_licence->club_id,
         'nom'                         => isset($_POST['nom']) ? sanitize_text_field(wp_unslash($_POST['nom'])) : '',
         'prenom'                      => isset($_POST['prenom']) ? sanitize_text_field(wp_unslash($_POST['prenom'])) : '',
         'sexe'                        => (isset($_POST['sexe']) && wp_unslash($_POST['sexe']) === 'F') ? 'F' : 'M',
@@ -81,6 +82,10 @@ if (isset($_SERVER['REQUEST_METHOD']) && $_SERVER['REQUEST_METHOD'] === 'POST' &
         echo '<div class="notice notice-success"><p>✅ Licence modifiée avec succès.</p></div>';
         // Reload the licence data to show updated values
         $current_licence = $manager->get_licence_by_id($licence_id);
+        $club = $wpdb->get_row($wpdb->prepare(
+            "SELECT * FROM {$wpdb->prefix}ufsc_clubs WHERE id = %d",
+            $current_licence->club_id
+        ));
     } else {
         echo '<div class="notice notice-error"><p>❌ Erreur lors de la modification de la licence.</p></div>';
     }

--- a/includes/licences/class-licence-manager.php
+++ b/includes/licences/class-licence-manager.php
@@ -231,6 +231,10 @@ class UFSC_Licence_Manager
             'is_included'                => !empty($data['is_included']) ? 1 : 0,
         ];
 
+        if (isset($data['club_id'])) {
+            $update['club_id'] = intval($data['club_id']);
+        }
+
         $result = $this->wpdb->update(
             $this->table_licences,
             $update,


### PR DESCRIPTION
## Summary
- Enable club selection in admin licence form
- Allow updating licence club and reload club details after save
- Update licence manager to persist club changes

## Testing
- `php -l includes/frontend/parts/form-licence.php`
- `php -l includes/licences/admin-licence-edit.php`
- `php -l includes/licences/class-licence-manager.php`
- `phpunit` *(fails: command not found)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ae8ee2f69c832b92a2f907eb34f593