### PR TITLE
Restrict editing for validated licences

### DIFF
--- a/includes/frontend/parts/form-licence.php
+++ b/includes/frontend/parts/form-licence.php
@@ -325,11 +325,11 @@ require_once plugin_dir_path(__FILE__) . '../../helpers.php';
 <?php if ($is_validated): ?>
 <script>
 document.addEventListener('DOMContentLoaded', function () {
-    var allowed = ['email', 'tel_mobile', 'tel_fixe'];
-    document.querySelectorAll('.ufsc-licence-form input, .ufsc-licence-form select, .ufsc-licence-form textarea').forEach(function (el) {
+    const allowed = ['email', 'tel_mobile', 'tel_fixe'];
+    document.querySelectorAll('.ufsc-licence-form input:not([type="hidden"]), .ufsc-licence-form select, .ufsc-licence-form textarea').forEach(function (el) {
         if (!allowed.includes(el.id)) {
-            el.setAttribute('readonly', 'readonly');
-            el.setAttribute('disabled', 'disabled');
+            el.readOnly = true;
+            el.disabled = true;
         }
     });
 });

--- a/includes/licences/admin-licence-edit.php
+++ b/includes/licences/admin-licence-edit.php
@@ -79,7 +79,7 @@ if (isset($_SERVER['REQUEST_METHOD']) && $_SERVER['REQUEST_METHOD'] === 'POST' &
 
     if ($is_validated) {
         $locked_fields = [
-            'nom', 'prenom', 'sexe', 'date_naissance', 'adresse', 'suite_adresse',
+            'club_id', 'nom', 'prenom', 'sexe', 'date_naissance', 'adresse', 'suite_adresse',
             'code_postal', 'ville', 'region', 'profession', 'identifiant_laposte',
             'reduction_benevole', 'reduction_postier', 'fonction_publique',
             'competition', 'licence_delegataire', 'numero_licence_delegataire',


### PR DESCRIPTION
## Summary
- Prevent editing of validated licences except for email and phone numbers
- Show notice when licence is validated and disable non-contact fields
- Harden admin update handler to ignore changes to locked fields, including club selection

## Testing
- `phpunit --version` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ae91d4a9d4832b8f61ebe28fb127a9