### PR TITLE
feat: manage licence payment status

### DIFF
--- a/includes/install/migrations.php
+++ b/includes/install/migrations.php
@@ -24,6 +24,12 @@ function ufsc_run_migrations() {
         $wpdb->query("ALTER TABLE {$licences_table} ADD COLUMN deleted_at datetime NULL DEFAULT NULL AFTER role");
     }
 
+    // Add payment_status column if missing
+    $col_pay = $wpdb->get_var($wpdb->prepare("SHOW COLUMNS FROM {$licences_table} LIKE %s", 'payment_status'));
+    if (!$col_pay) {
+        $wpdb->query("ALTER TABLE {$licences_table} ADD COLUMN payment_status VARCHAR(20) NOT NULL DEFAULT 'pending'");
+    }
+
     // Add helpful indexes
     $indexes = $wpdb->get_results("SHOW INDEX FROM {$licences_table}", ARRAY_A);
     $have_idx = function($name) use ($indexes) {


### PR DESCRIPTION
## Summary
- store and sanitize payment_status when creating a licence
- allow updating payment_status with normalization
- ensure database migration adds payment_status column

## Testing
- `php -l includes/licences/class-licence-manager.php`
- `php -l includes/install/migrations.php`
- `phpunit --configuration phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae97733dc8832bbcd820677f3005df