### PR TITLE
Secure licence table ordering and permissions

### DIFF
--- a/includes/licences/class-ufsc-licence-list-table.php
+++ b/includes/licences/class-ufsc-licence-list-table.php
@@ -37,7 +37,7 @@ class UFSC_Licence_List_Table extends WP_List_Table {
     protected function column_nom( $item ) {
         $actions = [];
 
-        if ( current_user_can( 'ufsc_manage_licences' ) ) {
+        if ( current_user_can( 'manage_ufsc_licenses' ) ) {
             $view_url = wp_nonce_url(
                 admin_url( 'admin.php?page=ufsc_view_licence&id=' . $item['id'] ),
                 'ufsc_view_licence_' . $item['id']
@@ -49,7 +49,7 @@ class UFSC_Licence_List_Table extends WP_List_Table {
             );
         }
 
-        if ( current_user_can( 'ufsc_manage_licences' ) ) {
+        if ( current_user_can( 'manage_ufsc_licenses' ) ) {
             $edit_url = wp_nonce_url(
                 admin_url( 'admin.php?page=ufsc-modifier-licence&licence_id=' . $item['id'] ),
                 'ufsc_edit_licence_' . $item['id']
@@ -137,8 +137,13 @@ class UFSC_Licence_List_Table extends WP_List_Table {
             $params[] = $like;
         }
 
-        $orderby = ! empty( $_REQUEST['orderby'] ) ? sanitize_sql_orderby( $_REQUEST['orderby'] ) : 'date_inscription';
-        $order   = ! empty( $_REQUEST['order'] ) && 'asc' === strtolower( $_REQUEST['order'] ) ? 'ASC' : 'DESC';
+        $allowed_orderby = [ 'id', 'nom', 'date_inscription' ];
+        $orderby         = isset( $_REQUEST['orderby'] ) ? sanitize_key( $_REQUEST['orderby'] ) : 'date_inscription';
+        if ( ! in_array( $orderby, $allowed_orderby, true ) ) {
+            $orderby = 'date_inscription';
+        }
+
+        $order = ! empty( $_REQUEST['order'] ) && 'asc' === strtolower( $_REQUEST['order'] ) ? 'ASC' : 'DESC';
 
         $count_sql = "SELECT COUNT(*) FROM {$table} l {$where}";
         if ( empty( $params ) ) {


### PR DESCRIPTION
## Summary
- Restrict licence list ordering to specific columns
- Use `manage_ufsc_licenses` capability for licence actions

## Testing
- `phpunit` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9feb6628832b8aa5d5303487bef8