### PR TITLE
Scope admin UI assets to licence screens

### DIFF
--- a/assets/css/ufsc-ui-admin.css
+++ b/assets/css/ufsc-ui-admin.css
@@ -1,0 +1,32 @@
+/* UFSC Admin scoped UI enhancements */
+.ufsc-admin .ufsc-wrap { max-width: 100%; }
+.ufsc-admin .ufsc-table { table-layout: fixed; width: 100%; border-collapse: separate; border-spacing: 0; }
+.ufsc-admin .ufsc-table th,
+.ufsc-admin .ufsc-table td { padding: 8px 10px; vertical-align: middle; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ufsc-admin .ufsc-table thead th { position: sticky; top: 32px; background: #fff; z-index: 1; }
+.ufsc-admin .ufsc-table tr:nth-child(even) { background: #fafafa; }
+.ufsc-admin .ufsc-col--actions { width: 180px; text-align: right; }
+.ufsc-admin .ufsc-actions { display: flex; justify-content: flex-end; flex-wrap: wrap; gap: 6px; }
+.ufsc-admin .ufsc-actions .button { height: 28px; line-height: 26px; padding: 0 8px; }
+
+@media (max-width: 1200px) {
+  .ufsc-admin .ufsc-col--email,
+  .ufsc-admin .ufsc-col--phone,
+  .ufsc-admin .ufsc-col--club { display: none; }
+  .ufsc-admin .ufsc-col--actions { width: 140px; }
+}
+
+@media (max-width: 960px) {
+  .ufsc-admin .ufsc-table,
+  .ufsc-admin .ufsc-table thead,
+  .ufsc-admin .ufsc-table tbody,
+  .ufsc-admin .ufsc-table th,
+  .ufsc-admin .ufsc-table td,
+  .ufsc-admin .ufsc-table tr { display: block; }
+  .ufsc-admin .ufsc-table thead { display: none; }
+  .ufsc-admin .ufsc-row { border: 1px solid #e5e7eb; border-radius: 10px; margin-bottom: 12px; background: #fff; }
+  .ufsc-admin .ufsc-row .ufsc-cell { display: grid; grid-template-columns: 120px 1fr; gap: 8px; padding: 8px 10px; }
+  .ufsc-admin .ufsc-row .ufsc-cell::before { content: attr(data-label); font-weight: 600; color: #111827; }
+  .ufsc-admin .ufsc-actions { justify-content: flex-start; padding: 8px 10px; }
+}
+

--- a/includes/admin/class-menu.php
+++ b/includes/admin/class-menu.php
@@ -36,56 +36,66 @@ class UFSC_Menu
      */
     public function enqueue_admin_scripts($hook)
     {
-        // Only enqueue on UFSC admin pages
-        if (strpos($hook, 'ufsc') === false && strpos($hook, 'plugin-ufsc-gestion-club') === false) {
-            return;
-        }
-
-        // Enqueue licence actions script on pages that manage licences
         $licence_pages = [
             'ufsc_page_ufsc-licences',
             'ufsc_page_ufsc-edit-club',
             'plugin-ufsc-gestion-club-13072025_page_ufsc-licences'
         ];
 
-        if (in_array($hook, $licence_pages) || strpos($hook, 'ufsc-licences') !== false || strpos($hook, 'ufsc-edit-club') !== false) {
-            wp_enqueue_script(
-                'ufsc-licence-actions',
-                UFSC_PLUGIN_URL . 'assets/js/admin-licence-actions.js',
-                ['jquery'],
-                UFSC_PLUGIN_VERSION,
-                true
-            );
-
-            // Enqueue admin licences table CSS
-            wp_enqueue_style(
-                'ufsc-admin-licences',
-                UFSC_PLUGIN_URL . 'assets/css/admin-licences.css',
-                [],
-                UFSC_PLUGIN_VERSION
-            );
-
-            // Localize script with nonces and AJAX URL
-            
-        // Enqueue enhanced admin UI styles/scripts for UFSC screens
-        wp_enqueue_style('ufsc-admin-ui', plugins_url('../../assets/css/ufsc-admin-ui.css', __FILE__), [], '1.0.0');
-        wp_enqueue_script('ufsc-admin-ui', plugins_url('../../assets/js/ufsc-admin-ui.js', __FILE__), [], '1.0.0', true);
-    
-            wp_localize_script('ufsc-licence-actions', 'ufscLicenceConfig', [
-                'ajaxUrl' => admin_url('admin-ajax.php'),
-                'nonces' => [
-                    'delete_licence' => wp_create_nonce('ufsc_delete_licence'),
-                    'change_licence_status' => wp_create_nonce('ufsc_change_licence_status'),
-                ],
-                'messages' => [
-                    'confirmDelete' => __('Êtes-vous sûr de vouloir supprimer cette licence ?', 'plugin-ufsc-gestion-club-13072025'),
-                    'deleteSuccess' => __('Licence supprimée avec succès.', 'plugin-ufsc-gestion-club-13072025'),
-                    'deleteError' => __('Erreur lors de la suppression.', 'plugin-ufsc-gestion-club-13072025'),
-                    'statusUpdateSuccess' => __('Statut mis à jour avec succès.', 'plugin-ufsc-gestion-club-13072025'),
-                    'statusUpdateError' => __('Erreur lors de la mise à jour du statut.', 'plugin-ufsc-gestion-club-13072025'),
-                ]
-            ]);
+        // Load assets only on licence management screens
+        if (!in_array($hook, $licence_pages, true)) {
+            return;
         }
+
+        // Licence actions script
+        wp_enqueue_script(
+            'ufsc-licence-actions',
+            UFSC_PLUGIN_URL . 'assets/js/admin-licence-actions.js',
+            ['jquery'],
+            UFSC_PLUGIN_VERSION,
+            true
+        );
+
+        // Licence table styles
+        wp_enqueue_style(
+            'ufsc-admin-licences',
+            UFSC_PLUGIN_URL . 'assets/css/admin-licences.css',
+            [],
+            UFSC_PLUGIN_VERSION
+        );
+
+        // Scoped admin UI enhancements
+        wp_register_style(
+            'ufsc-admin-ui',
+            UFSC_PLUGIN_URL . 'assets/css/ufsc-ui-admin.css',
+            [],
+            UFSC_PLUGIN_VERSION
+        );
+        wp_register_script(
+            'ufsc-admin-ui',
+            UFSC_PLUGIN_URL . 'assets/js/ufsc-admin-ui.js',
+            [],
+            UFSC_PLUGIN_VERSION,
+            true
+        );
+        wp_enqueue_style('ufsc-admin-ui');
+        wp_enqueue_script('ufsc-admin-ui');
+
+        // Localize script with nonces and AJAX URL
+        wp_localize_script('ufsc-licence-actions', 'ufscLicenceConfig', [
+            'ajaxUrl' => admin_url('admin-ajax.php'),
+            'nonces' => [
+                'delete_licence' => wp_create_nonce('ufsc_delete_licence'),
+                'change_licence_status' => wp_create_nonce('ufsc_change_licence_status'),
+            ],
+            'messages' => [
+                'confirmDelete' => __('Êtes-vous sûr de vouloir supprimer cette licence ?', 'plugin-ufsc-gestion-club-13072025'),
+                'deleteSuccess' => __('Licence supprimée avec succès.', 'plugin-ufsc-gestion-club-13072025'),
+                'deleteError' => __('Erreur lors de la suppression.', 'plugin-ufsc-gestion-club-13072025'),
+                'statusUpdateSuccess' => __('Statut mis à jour avec succès.', 'plugin-ufsc-gestion-club-13072025'),
+                'statusUpdateError' => __('Erreur lors de la mise à jour du statut.', 'plugin-ufsc-gestion-club-13072025'),
+            ]
+        ]);
     }
 
     /**


### PR DESCRIPTION
## Summary
- Register admin UI assets and load them only on licence management pages
- Add scoped UFSC admin stylesheet for sticky headers, zebra rows and responsive layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `phpunit` *(fails: command not found)*
- `php -l includes/admin/class-menu.php`


------
https://chatgpt.com/codex/tasks/task_e_68ae9fe7dfdc832b92fc780530cdd3a4