### PR TITLE
Add licence and club repository layers

### DIFF
--- a/Plugin_UFSC_GESTION_CLUB_13072025.php
+++ b/Plugin_UFSC_GESTION_CLUB_13072025.php
@@ -2492,9 +2492,9 @@ function ufsc_admin_post_delete_licence() {
 
     check_admin_referer('ufsc_delete_licence_' . $licence_id);
 
-    require_once UFSC_PLUGIN_PATH . 'includes/licences/class-licence-manager.php';
-    $manager = UFSC_Licence_Manager::get_instance();
-    $success = $manager->delete_licence($licence_id);
+    require_once UFSC_PLUGIN_PATH . 'includes/licences/class-ufsc-licenses-repository.php';
+    $repo = new UFSC_Licenses_Repository();
+    $success = $repo->soft_delete($licence_id);
 
     $message  = $success ? 'deleted' : 'delete_error';
     $redirect = add_query_arg([
@@ -2525,15 +2525,9 @@ function ufsc_admin_post_reassign_licence() {
 
     check_admin_referer('ufsc_reassign_licence_' . $licence_id);
 
-    global $wpdb;
-    $table   = $wpdb->prefix . 'ufsc_licences';
-    $updated = $wpdb->update(
-        $table,
-        ['club_id' => $new_club_id],
-        ['id' => $licence_id],
-        ['%d'],
-        ['%d']
-    );
+    require_once UFSC_PLUGIN_PATH . 'includes/licences/class-ufsc-licenses-repository.php';
+    $repo = new UFSC_Licenses_Repository();
+    $updated = $repo->update($licence_id, ['club_id' => $new_club_id]);
 
     $message  = $updated !== false ? 'reassigned' : 'reassign_error';
     $redirect = add_query_arg([

--- a/includes/clubs/class-ufsc-clubs-repository.php
+++ b/includes/clubs/class-ufsc-clubs-repository.php
@@ -1,0 +1,36 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Repository for UFSC clubs operations.
+ */
+class UFSC_Clubs_Repository {
+    /** @var wpdb */
+    private $wpdb;
+
+    /** @var string */
+    private $table;
+
+    public function __construct() {
+        global $wpdb;
+        $this->wpdb  = $wpdb;
+        $this->table = $wpdb->prefix . 'ufsc_clubs';
+    }
+
+    /**
+     * Search clubs by term for AJAX typeahead.
+     *
+     * @param string $term Search term.
+     * @return array List of matching clubs (id, nom).
+     */
+    public function search($term) {
+        $like = '%' . $this->wpdb->esc_like($term) . '%';
+        $sql  = $this->wpdb->prepare(
+            "SELECT id, nom FROM {$this->table} WHERE nom LIKE %s ORDER BY nom ASC LIMIT 10",
+            $like
+        );
+        return $this->wpdb->get_results($sql);
+    }
+}

--- a/includes/frontend/parts/licence-list.php
+++ b/includes/frontend/parts/licence-list.php
@@ -13,13 +13,15 @@ if (!$club_id) {
 }
 
 require_once dirname(__DIR__, 2) . '/licences/class-licence-filters.php';
+require_once dirname(__DIR__, 2) . '/licences/class-ufsc-licenses-repository.php';
 
 $filters = UFSC_Licence_Filters::get_filter_parameters(['club_id' => $club_id]);
 if (empty($filters['statuses'])) {
     // By default only show validated licences or those without a status
     $filters['statuses'] = ['validee', ''];
 }
-$license_data = UFSC_Licence_Filters::get_filtered_licenses($filters);
+$repo = new UFSC_Licenses_Repository();
+$license_data = $repo->get_list($filters);
 $licences = $license_data['data'];
 $search = $filters['search_global'];
 ?>

--- a/includes/licences/admin-licence-edit.php
+++ b/includes/licences/admin-licence-edit.php
@@ -3,8 +3,8 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-// ✅ Chargement du gestionnaire de licences
-require_once UFSC_PLUGIN_PATH . 'includes/licences/class-licence-manager.php';
+// ✅ Chargement du dépôt de licences
+require_once UFSC_PLUGIN_PATH . 'includes/licences/class-ufsc-licenses-repository.php';
 
 global $wpdb;
 $licence_id = isset($_GET['licence_id']) ? intval(wp_unslash($_GET['licence_id'])) : 0;
@@ -22,8 +22,8 @@ if (!isset($_GET['_wpnonce']) || !wp_verify_nonce(wp_unslash($_GET['_wpnonce']),
     wp_die(__('Action non autorisée.', 'plugin-ufsc-gestion-club-13072025'));
 }
 
-$manager = new UFSC_Licence_Manager();
-$current_licence = $manager->get_licence_by_id($licence_id);
+$repo = new UFSC_Licenses_Repository();
+$current_licence = $repo->get($licence_id);
 $is_validated = $current_licence && $current_licence->statut === 'validee';
 
 if (!$current_licence) {
@@ -92,12 +92,12 @@ if (isset($_SERVER['REQUEST_METHOD']) && $_SERVER['REQUEST_METHOD'] === 'POST' &
         }
     }
 
-    $success = $manager->update_licence($licence_id, $data);
+    $success = $repo->update($licence_id, $data);
 
     if ($success) {
         echo '<div class="notice notice-success"><p>✅ Licence modifiée avec succès.</p></div>';
         // Reload the licence data to show updated values
-        $current_licence = $manager->get_licence_by_id($licence_id);
+        $current_licence = $repo->get($licence_id);
         $club = $wpdb->get_row($wpdb->prepare(
             "SELECT * FROM {$wpdb->prefix}ufsc_clubs WHERE id = %d",
             $current_licence->club_id

--- a/includes/licences/admin-licence-list.php
+++ b/includes/licences/admin-licence-list.php
@@ -6,6 +6,7 @@ if (!defined('ABSPATH')) {
 require_once plugin_dir_path(__FILE__) . 'class-ufsc-licence-list-table.php';
 require_once plugin_dir_path(__FILE__) . '../helpers.php';
 require_once plugin_dir_path(__FILE__) . '../helpers/helpers-licence-status.php';
+require_once plugin_dir_path(__FILE__) . 'class-ufsc-licenses-repository.php';
 
 global $wpdb;
 
@@ -71,8 +72,9 @@ wp_enqueue_script(
 // Get filter parameters with club_id override, allowing precomputed filters
 $filters = isset($filters) ? $filters : UFSC_Licence_Filters::get_filter_parameters(['club_id' => $club_id]);
 
-// Retrieve licence data for display
-$license_data = UFSC_Licence_Filters::get_filtered_licenses($filters);
+// Retrieve licence data via repository
+$repo = new UFSC_Licenses_Repository();
+$license_data = $repo->get_list($filters);
 
 $no_license_notice = '';
 if (empty($license_data['data'])) {
@@ -104,12 +106,8 @@ if (empty($license_data['data'])) {
 }
 
 $list_table = new UFSC_Licence_List_Table($club_id);
+$list_table->set_external_data($license_data['data'], $license_data['total_items'], $license_data['per_page']);
 $list_table->prepare_items();
-$list_table->items = array_map('get_object_vars', $license_data['data']);
-$list_table->set_pagination_args([
-    'total_items' => $license_data['total_items'],
-    'per_page'    => $license_data['per_page'],
-]);
 
 // 📤 Export CSV
 if (isset($_GET['export_csv']) && check_admin_referer('ufsc_export_licences_' . $club_id)) {

--- a/includes/licences/class-ufsc-licence-list-table.php
+++ b/includes/licences/class-ufsc-licence-list-table.php
@@ -8,6 +8,7 @@ if ( ! class_exists( 'WP_List_Table' ) ) {
 
 class UFSC_Licence_List_Table extends WP_List_Table {
     protected $club_id = 0;
+    private $external_data = null;
 
     public function __construct( $club_id = 0 ) {
         $this->club_id = (int) $club_id;
@@ -113,7 +114,28 @@ class UFSC_Licence_List_Table extends WP_List_Table {
         ];
     }
 
+    public function set_external_data($data, $total_items, $per_page) {
+        $this->external_data = [
+            'items'       => array_map('get_object_vars', $data),
+            'total_items' => (int) $total_items,
+            'per_page'    => (int) $per_page,
+        ];
+    }
+
     public function prepare_items() {
+        if ($this->external_data) {
+            $this->items = $this->external_data['items'];
+            $total_items = $this->external_data['total_items'];
+            $per_page    = $this->external_data['per_page'];
+            $total_pages = (int) ceil($total_items / $per_page);
+            $this->set_pagination_args([
+                'total_items' => $total_items,
+                'per_page'    => $per_page,
+                'total_pages' => $total_pages,
+            ]);
+            return;
+        }
+
         global $wpdb;
         $per_page = 20;
         $current_page = $this->get_pagenum();

--- a/includes/licences/class-ufsc-licenses-repository.php
+++ b/includes/licences/class-ufsc-licenses-repository.php
@@ -1,0 +1,172 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Repository for UFSC licences operations.
+ */
+class UFSC_Licenses_Repository {
+    /** @var wpdb */
+    private $wpdb;
+
+    /** @var string */
+    private $table;
+
+    /** @var string */
+    private $clubs_table;
+
+    public function __construct() {
+        global $wpdb;
+        $this->wpdb       = $wpdb;
+        $this->table      = $wpdb->prefix . 'ufsc_licences';
+        $this->clubs_table = $wpdb->prefix . 'ufsc_clubs';
+        require_once plugin_dir_path(__FILE__) . 'class-licence-filters.php';
+    }
+
+    /**
+     * Fetch licences list with optional filters and pagination.
+     *
+     * @param array $args Filters including per_page and page.
+     * @return array { data, total_items, per_page, current_page }
+     */
+    public function get_list($args = []) {
+        $defaults = [
+            'page'      => 1,
+            'per_page'  => 20,
+        ];
+        $filters = array_merge($defaults, (array)$args);
+
+        $where_data  = UFSC_Licence_Filters::build_where_clause($filters);
+        $where       = $where_data['where_clause'];
+        $params      = $where_data['params'];
+
+        // Count
+        $count_sql = "SELECT COUNT(*) FROM {$this->table} l LEFT JOIN {$this->clubs_table} c ON l.club_id = c.id WHERE {$where}";
+        $prepared_count = empty($params) ? $this->wpdb->prepare($count_sql) : $this->wpdb->prepare($count_sql, $params);
+        $total_items    = (int)$this->wpdb->get_var($prepared_count);
+
+        // Pagination
+        $offset = ((int)$filters['page'] - 1) * (int)$filters['per_page'];
+        $params[] = (int)$filters['per_page'];
+        $params[] = (int)$offset;
+
+        $list_sql = "SELECT l.*, c.nom as club_nom FROM {$this->table} l LEFT JOIN {$this->clubs_table} c ON l.club_id = c.id WHERE {$where} ORDER BY l.date_inscription DESC LIMIT %d OFFSET %d";
+        $prepared_list = $this->wpdb->prepare($list_sql, $params);
+        $data = $this->wpdb->get_results($prepared_list);
+
+        return [
+            'data'         => $data,
+            'total_items'  => $total_items,
+            'per_page'     => (int)$filters['per_page'],
+            'current_page' => (int)$filters['page'],
+        ];
+    }
+
+    /**
+     * Get a licence by ID.
+     *
+     * @param int $id Licence ID.
+     * @return object|null
+     */
+    public function get($id) {
+        $sql = $this->wpdb->prepare("SELECT * FROM {$this->table} WHERE id = %d", (int)$id);
+        return $this->wpdb->get_row($sql);
+    }
+
+    /**
+     * Insert a licence record.
+     *
+     * @param array $data Associative data.
+     * @return int Inserted ID.
+     */
+    public function insert($data) {
+        list($fields, $placeholders, $values) = $this->prepare_insert($data);
+        $sql = "INSERT INTO {$this->table} ({$fields}) VALUES ({$placeholders})";
+        $this->wpdb->query($this->wpdb->prepare($sql, $values));
+        return (int)$this->wpdb->insert_id;
+    }
+
+    /**
+     * Update a licence.
+     *
+     * @param int $id Licence ID.
+     * @param array $data Data to update.
+     * @return bool
+     */
+    public function update($id, $data) {
+        list($set, $values) = $this->prepare_set($data);
+        $values[] = (int)$id;
+        $sql = "UPDATE {$this->table} SET {$set} WHERE id = %d";
+        return false !== $this->wpdb->query($this->wpdb->prepare($sql, $values));
+    }
+
+    /**
+     * Soft delete a licence (move to trash).
+     *
+     * @param int $id Licence ID.
+     * @return bool
+     */
+    public function soft_delete($id) {
+        $sql = "UPDATE {$this->table} SET statut = %s, deleted_at = %s WHERE id = %d";
+        $prepared = $this->wpdb->prepare($sql, 'trash', current_time('mysql'), (int)$id);
+        return false !== $this->wpdb->query($prepared);
+    }
+
+    /**
+     * Restore a soft deleted licence.
+     *
+     * @param int $id Licence ID.
+     * @return bool
+     */
+    public function restore($id) {
+        $sql = "UPDATE {$this->table} SET statut = %s, deleted_at = NULL WHERE id = %d";
+        $prepared = $this->wpdb->prepare($sql, 'en_attente', (int)$id);
+        return false !== $this->wpdb->query($prepared);
+    }
+
+    /**
+     * Change licence status.
+     *
+     * @param int    $id     Licence ID.
+     * @param string $status New status.
+     * @return bool
+     */
+    public function change_status($id, $status) {
+        $sql = "UPDATE {$this->table} SET statut = %s WHERE id = %d";
+        $prepared = $this->wpdb->prepare($sql, sanitize_text_field($status), (int)$id);
+        return false !== $this->wpdb->query($prepared);
+    }
+
+    private function prepare_insert($data) {
+        $fields = [];
+        $placeholders = [];
+        $values = [];
+        foreach ($data as $field => $value) {
+            $fields[] = $field;
+            if (is_numeric($value)) {
+                $placeholders[] = '%d';
+                $values[] = (int)$value;
+            } else {
+                $placeholders[] = '%s';
+                $values[] = (string)$value;
+            }
+        }
+        return [implode(',', $fields), implode(',', $placeholders), $values];
+    }
+
+    private function prepare_set($data) {
+        $parts = [];
+        $values = [];
+        foreach ($data as $field => $value) {
+            if (is_numeric($value)) {
+                $parts[] = "$field = %d";
+                $values[] = (int)$value;
+            } else {
+                $parts[] = "$field = %s";
+                $values[] = (string)$value;
+            }
+        }
+        return [implode(', ', $parts), $values];
+    }
+}


### PR DESCRIPTION
## Summary
- introduce UFSC_Licenses_Repository with CRUD, status and soft delete helpers
- add UFSC_Clubs_Repository with typeahead search
- refactor licence list and edit pages plus related admin handlers to use repositories

## Testing
- `phpunit --testsuite core` *(fails: command not found)*
- `php -l includes/licences/class-ufsc-licenses-repository.php`
- `php -l includes/clubs/class-ufsc-clubs-repository.php`
- `php -l includes/licences/admin-licence-edit.php`
- `php -l includes/licences/admin-licence-list.php`
- `php -l includes/licences/class-ufsc-licence-list-table.php`
- `php -l includes/frontend/parts/licence-list.php`
- `php -l Plugin_UFSC_GESTION_CLUB_13072025.php`


------
https://chatgpt.com/codex/tasks/task_e_68ae9fd390c0832b8bccdf705d574933