### PR TITLE
feat: add responsive form utilities

### DIFF
--- a/assets/css/ufsc-ui.css
+++ b/assets/css/ufsc-ui.css
@@ -1,0 +1,58 @@
+/* UFSC generic form UI */
+.ufsc-auto-2cols {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--ufsc-gap);
+}
+@media (min-width: 992px) {
+  .ufsc-auto-2cols {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.ufsc-full {
+  grid-column: 1 / -1;
+}
+
+.ufsc-auto-2cols input[type="text"],
+.ufsc-auto-2cols input[type="email"],
+.ufsc-auto-2cols input[type="password"],
+.ufsc-auto-2cols input[type="date"],
+.ufsc-auto-2cols input[type="tel"],
+.ufsc-auto-2cols select,
+.ufsc-auto-2cols textarea {
+  height: 44px;
+  border: 1px solid #ccc;
+  border-radius: 10px;
+  padding: 0 12px;
+}
+.ufsc-auto-2cols textarea {
+  height: auto;
+  padding: 12px;
+}
+
+.ufsc-auto-2cols input:focus,
+.ufsc-auto-2cols select:focus,
+.ufsc-auto-2cols textarea:focus {
+  outline: 2px solid var(--ufsc-accent);
+  outline-offset: 2px;
+}
+
+.ufsc-auto-2cols label {
+  display: block;
+  margin-bottom: 4px;
+}
+
+.ufsc-auto-2cols [required]::after {
+  content: "*";
+  margin-left: 4px;
+  color: var(--ufsc-accent);
+}
+
+.ufsc-auto-2cols .ufsc-form-error,
+.ufsc-auto-2cols .ufsc-error {
+  display: block;
+  margin-top: 4px;
+  font-size: 0.875rem;
+  color: var(--ufsc-danger, #d00);
+}

--- a/includes/class-ufsc-assets.php
+++ b/includes/class-ufsc-assets.php
@@ -28,6 +28,7 @@ class UFSC_Fix_Assets {
         wp_enqueue_script('datatables', 'https://cdn.datatables.net/1.13.8/js/jquery.dataTables.min.js', ['jquery'], '1.13.8', true);
 
         wp_enqueue_style('ufsc-front-fixes', plugins_url('assets/css/ufsc-front.css', dirname(__FILE__)), [], '20.3');
+        wp_enqueue_style('ufsc-ui', plugins_url('assets/css/ufsc-ui.css', dirname(__FILE__)), [], '1.0');
         // JS
         $deps = ['jquery'];
         wp_enqueue_script('ufsc-front-fixes', plugins_url('assets/js/ufsc-front.js', dirname(__FILE__)), $deps, '20.3', true);

--- a/includes/frontend/forms/affiliation-form-render.php
+++ b/includes/frontend/forms/affiliation-form-render.php
@@ -118,30 +118,30 @@ function ufsc_render_affiliation_form($args = [])
     // Club information section
     $output .= '<fieldset class="ufsc-form-section">
         <legend>Informations du club</legend>
-        <div class="ufsc-form-field">
+        <div class="ufsc-form-field ufsc-full">
             <label for="nom">Nom du club *</label>
             <input type="text" id="nom" name="nom" required maxlength="200" value="' . ($existing_club ? esc_attr($existing_club->nom) : '') . '">
             <p class="ufsc-form-hint"></p>
             <span class="ufsc-form-error"></span>
         </div>
-        
-        <div class="ufsc-form-field">
+
+        <div class="ufsc-form-field ufsc-full">
             <label for="description">Description du club</label>
             <textarea id="description" name="description" rows="4" maxlength="1000">' . ($existing_club ? esc_textarea($existing_club->description) : '') . '</textarea>
             <p class="ufsc-form-hint"></p>
             <span class="ufsc-form-error"></span>
         </div>
-        
-        <div class="ufsc-form-grid">
-            <div class="ufsc-form-field">
+
+        <div class="ufsc-form-grid ufsc-auto-2cols">
+            <div class="ufsc-form-field ufsc-full">
                 <label for="adresse">Adresse *</label>
                 <input type="text" id="adresse" name="adresse" required maxlength="200" value="' . ($existing_club ? esc_attr($existing_club->adresse) : '') . '">
                 <p class="ufsc-form-hint"></p>
                 <span class="ufsc-form-error"></span>
             </div>
         </div>
-        
-        <div class="ufsc-form-grid">
+
+        <div class="ufsc-form-grid ufsc-auto-2cols">
             <div class="ufsc-form-field">
                 <label for="code_postal">Code postal *</label>
                 <input type="text" id="code_postal" name="code_postal" required pattern="[0-9]{5}" maxlength="5" value="' . ($existing_club ? esc_attr($existing_club->code_postal) : '') . '">
@@ -159,7 +159,7 @@ function ufsc_render_affiliation_form($args = [])
     // Region selection
     if (!empty($regions)) {
         $selected_region = $existing_club ? $existing_club->region : '';
-        $output .= '<div class="ufsc-form-field">
+        $output .= '<div class="ufsc-form-field ufsc-full">
             <label for="region">Région UFSC *</label>
             <select id="region" name="region" required>
                 <option value="">Sélectionner une région...</option>';
@@ -180,7 +180,7 @@ function ufsc_render_affiliation_form($args = [])
     // Contact information section
     $output .= '<fieldset class="ufsc-form-section">
         <legend>Contact</legend>
-        <div class="ufsc-form-grid">
+        <div class="ufsc-form-grid ufsc-auto-2cols">
             <div class="ufsc-form-field">
                 <label for="email">Email *</label>
                 <input type="email" id="email" name="email" required maxlength="150" value="' . ($existing_club ? esc_attr($existing_club->email) : '') . '">
@@ -194,8 +194,8 @@ function ufsc_render_affiliation_form($args = [])
                 <span class="ufsc-form-error"></span>
             </div>
         </div>
-        
-        <div class="ufsc-form-field">
+
+        <div class="ufsc-form-field ufsc-full">
             <label for="site_web">Site web</label>
             <input type="url" id="site_web" name="site_web" maxlength="200" placeholder="https://" value="' . ($existing_club ? esc_attr($existing_club->site_web) : '') . '">
             <p class="ufsc-form-hint"></p>
@@ -206,7 +206,7 @@ function ufsc_render_affiliation_form($args = [])
     // Additional information section
     $output .= '<fieldset class="ufsc-form-section">
         <legend>Informations complémentaires</legend>
-        <div class="ufsc-form-grid">
+        <div class="ufsc-form-grid ufsc-auto-2cols">
             <div class="ufsc-form-field">
                 <label for="siret">SIRET</label>
                 <input type="text" id="siret" name="siret" maxlength="14" pattern="[0-9]{14}" value="' . ($existing_club ? esc_attr($existing_club->siret) : '') . '">
@@ -221,7 +221,7 @@ function ufsc_render_affiliation_form($args = [])
             </div>
         </div>
         
-        <div class="ufsc-form-field">
+        <div class="ufsc-form-field ufsc-full">
             <label for="activites">Activités pratiquées</label>
             <textarea id="activites" name="activites" rows="3" maxlength="500" placeholder="Décrivez les activités sportives proposées par votre club...">' . ($existing_club ? esc_textarea($existing_club->activites) : '') . '</textarea>
             <p class="ufsc-form-hint"></p>

--- a/includes/frontend/forms/licence-form-render.php
+++ b/includes/frontend/forms/licence-form-render.php
@@ -69,7 +69,7 @@ function ufsc_render_licence_form($args = array()){
 
       <fieldset class="ufsc-form-section">
         <legend>Informations personnelles</legend>
-        <div class="ufsc-form-grid">
+        <div class="ufsc-form-grid ufsc-auto-2cols">
           <div class="ufsc-form-field">
             <label for="nom">Nom *</label>
             <input type="text" id="nom" name="nom" required maxlength="100" value="<?php echo $v('nom'); ?>">
@@ -84,7 +84,7 @@ function ufsc_render_licence_form($args = array()){
           </div>
         </div>
 
-        <div class="ufsc-form-grid">
+        <div class="ufsc-form-grid ufsc-auto-2cols">
           <div class="ufsc-form-field">
             <label for="date_naissance">Date de naissance *</label>
             <input type="date" id="date_naissance" name="date_naissance" required value="<?php echo $v('date_naissance'); ?>">
@@ -103,7 +103,7 @@ function ufsc_render_licence_form($args = array()){
           </div>
         </div>
 
-        <div class="ufsc-form-field">
+        <div class="ufsc-form-field ufsc-full">
           <label for="email">Email *</label>
           <input type="email" id="email" name="email" required maxlength="150" value="<?php echo $v('email'); ?>">
           <p class="ufsc-form-hint"></p>
@@ -113,13 +113,13 @@ function ufsc_render_licence_form($args = array()){
 
       <fieldset class="ufsc-form-section">
         <legend>Coordonnées</legend>
-        <div class="ufsc-form-field">
+        <div class="ufsc-form-field ufsc-full">
           <label for="adresse">Adresse</label>
           <input type="text" id="adresse" name="adresse" maxlength="200" value="<?php echo $v('adresse'); ?>">
           <p class="ufsc-form-hint"></p>
           <span class="ufsc-form-error"></span>
         </div>
-        <div class="ufsc-form-grid">
+        <div class="ufsc-form-grid ufsc-auto-2cols">
           <div class="ufsc-form-field">
             <label for="suite_adresse">Complément d'adresse</label>
             <input type="text" id="suite_adresse" name="suite_adresse" maxlength="200" value="<?php echo $v('suite_adresse'); ?>">
@@ -133,13 +133,13 @@ function ufsc_render_licence_form($args = array()){
             <span class="ufsc-form-error"></span>
           </div>
         </div>
-        <div class="ufsc-form-field">
+        <div class="ufsc-form-field ufsc-full">
           <label for="ville">Ville</label>
           <input type="text" id="ville" name="ville" maxlength="120" value="<?php echo $v('ville'); ?>">
           <p class="ufsc-form-hint"></p>
           <span class="ufsc-form-error"></span>
         </div>
-        <div class="ufsc-form-grid">
+        <div class="ufsc-form-grid ufsc-auto-2cols">
           <div class="ufsc-form-field">
             <label for="tel_mobile">Téléphone</label>
             <input type="text" id="tel_mobile" name="tel_mobile" maxlength="25" value="<?php echo $v('tel_mobile'); ?>">
@@ -157,7 +157,7 @@ function ufsc_render_licence_form($args = array()){
 
       <fieldset class="ufsc-form-section">
         <legend>Rôle & type</legend>
-        <div class="ufsc-form-grid">
+        <div class="ufsc-form-grid ufsc-auto-2cols">
           <div class="ufsc-form-field">
             <label for="fonction">Fonction</label>
             <select id="fonction" name="fonction">
@@ -178,7 +178,7 @@ function ufsc_render_licence_form($args = array()){
             <span class="ufsc-form-error"></span>
           </div>
         </div>
-        <div class="ufsc-form-grid">
+        <div class="ufsc-form-grid ufsc-auto-2cols">
           <div class="ufsc-form-field">
             <label for="licence_delegataire">Licence délégataire</label>
             <input type="checkbox" id="licence_delegataire" name="licence_delegataire" value="1"<?php echo $is_checked('licence_delegataire'); ?>>
@@ -196,7 +196,7 @@ function ufsc_render_licence_form($args = array()){
 
       <fieldset class="ufsc-form-section">
         <legend>Autorisations et communications</legend>
-        <div class="ufsc-form-grid">
+        <div class="ufsc-form-grid ufsc-auto-2cols">
           <div class="ufsc-form-field">
             <label for="diffusion_image">Consentement diffusion image</label>
             <input type="checkbox" id="diffusion_image" name="diffusion_image" value="1"<?php echo $is_checked('diffusion_image'); ?>>
@@ -232,7 +232,7 @@ function ufsc_render_licence_form($args = array()){
 
       <fieldset class="ufsc-form-section">
         <legend>Déclarations et assurances</legend>
-        <div class="ufsc-form-grid">
+        <div class="ufsc-form-grid ufsc-auto-2cols">
           <div class="ufsc-form-field">
             <label for="honorabilite">Déclaration d'honorabilité</label>
             <input type="checkbox" id="honorabilite" name="honorabilite" value="1"<?php echo $is_checked('honorabilite'); ?>>
@@ -256,7 +256,7 @@ function ufsc_render_licence_form($args = array()){
 
       <fieldset class="ufsc-form-section">
         <legend>Règlements</legend>
-        <div class="ufsc-form-field">
+        <div class="ufsc-form-field ufsc-full">
           <label for="ufsc_rules_ack">J'ai pris connaissance des règlements — <a href="https://ufsc-france.fr/ufsc-reglements-sportifs-techniques-interieur/" target="_blank" rel="noopener">Lire les règlements</a></label>
           <input type="checkbox" id="ufsc_rules_ack" name="ufsc_rules_ack" value="1" required>
           <p class="ufsc-form-hint"></p>

--- a/includes/frontend/shortcodes/login-register-shortcode.php
+++ b/includes/frontend/shortcodes/login-register-shortcode.php
@@ -123,32 +123,32 @@ function ufsc_render_logged_in_message() {
 function ufsc_render_registration_form() {
     $output = '<div class="ufsc-card">';
     $output .= '<h3>' . __('Inscription', 'plugin-ufsc-gestion-club-13072025') . '</h3>';
-    $output .= '<form method="post" class="ufsc-form" id="ufsc-register-form">';
+    $output .= '<form method="post" class="ufsc-form ufsc-auto-2cols" id="ufsc-register-form">';
     
     // Nonce field for security
     $output .= wp_nonce_field('ufsc_register_nonce', 'ufsc_register_nonce', true, false);
     
     // Email field
-    $output .= '<div class="ufsc-form-row">';
+    $output .= '<div class="ufsc-form-row ufsc-full">';
     $output .= '<label for="ufsc_register_email">' . __('Email', 'plugin-ufsc-gestion-club-13072025') . ' <span class="required">*</span></label>';
     $output .= '<input type="email" id="ufsc_register_email" name="ufsc_register_email" required value="' . esc_attr(isset($_POST['ufsc_register_email']) ? $_POST['ufsc_register_email'] : '') . '">';
     $output .= '</div>';
     
     // Password field
-    $output .= '<div class="ufsc-form-row">';
+    $output .= '<div class="ufsc-form-row ufsc-full">';
     $output .= '<label for="ufsc_register_password">' . __('Mot de passe', 'plugin-ufsc-gestion-club-13072025') . ' <span class="required">*</span></label>';
     $output .= '<input type="password" id="ufsc_register_password" name="ufsc_register_password" required minlength="8">';
     $output .= '<small class="description">' . __('Minimum 8 caractères', 'plugin-ufsc-gestion-club-13072025') . '</small>';
     $output .= '</div>';
     
     // Password confirmation field
-    $output .= '<div class="ufsc-form-row">';
+    $output .= '<div class="ufsc-form-row ufsc-full">';
     $output .= '<label for="ufsc_register_password_confirm">' . __('Confirmer le mot de passe', 'plugin-ufsc-gestion-club-13072025') . ' <span class="required">*</span></label>';
     $output .= '<input type="password" id="ufsc_register_password_confirm" name="ufsc_register_password_confirm" required minlength="8">';
     $output .= '</div>';
     
     // Submit button
-    $output .= '<div class="ufsc-form-row">';
+    $output .= '<div class="ufsc-form-row ufsc-full">';
     $output .= '<button type="submit" name="ufsc_register_submit" class="ufsc-btn ufsc-btn-primary">';
     $output .= __('S\'inscrire', 'plugin-ufsc-gestion-club-13072025');
     $output .= '</button>';


### PR DESCRIPTION
## Summary
- introduce ufsc-auto-2cols grid and ufsc-full helpers
- apply new layout classes to registration, licence, and affiliation forms
- enqueue new ufsc-ui stylesheet

## Testing
- `npm test` *(fails: Missing script)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9f660ecc832bb357090a66e7821e