### PR TITLE
style: unify ui actions and table styling

### DIFF
--- a/assets/css/ufsc-ui.css
+++ b/assets/css/ufsc-ui.css
@@ -1,0 +1,51 @@
+/* UFSC generic UI styles */
+
+/* Action buttons container */
+.ufsc-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: flex-end;
+  min-width: 90px; /* 120px recommended */
+}
+.ufsc-actions:empty {
+  display: none;
+}
+
+/* Tables */
+.ufsc-table th,
+.ufsc-table td {
+  padding: 12px 14px;
+  vertical-align: middle;
+}
+.ufsc-table tbody tr:nth-child(odd) {
+  background: #f9f9f9;
+}
+.ufsc-table thead th {
+  position: sticky;
+  top: 0;
+  background: #fff;
+  z-index: 1;
+}
+
+/* Status badges */
+.ufsc-badge {
+  display: inline-block;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #fff;
+}
+.ufsc-badge--ok { background: #2e7d32; }
+.ufsc-badge--warn { background: #f57c00; }
+.ufsc-badge--err { background: #d32f2f; }
+.ufsc-badge--pending { background: #616161; }
+.ufsc-badge--expired { background: #5d4037; }
+
+/* Text ellipsis */
+.ufsc-text-ellipsis {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}

--- a/includes/licences/class-ufsc-licence-list-table.php
+++ b/includes/licences/class-ufsc-licence-list-table.php
@@ -91,7 +91,19 @@ class UFSC_Licence_List_Table extends WP_List_Table {
             );
         }
 
-        return sprintf( '%1$s %2$s', esc_html( $item['nom'] ), $this->row_actions( $actions ) );
+        $nom = esc_html( $item['nom'] );
+        $name_html = '<span class="ufsc-text-ellipsis" title="' . esc_attr( $item['nom'] ) . '">' . $nom . '</span>';
+        return sprintf( '%1$s %2$s', $name_html, $this->row_actions( $actions ) );
+    }
+
+    protected function column_prenom( $item ) {
+        $prenom = esc_html( $item['prenom'] );
+        return '<span class="ufsc-text-ellipsis" title="' . esc_attr( $item['prenom'] ) . '">' . $prenom . '</span>';
+    }
+
+    protected function column_email( $item ) {
+        $email = esc_html( $item['email'] );
+        return '<span class="ufsc-text-ellipsis" title="' . esc_attr( $item['email'] ) . '">' . $email . '</span>';
     }
 
     protected function column_default( $item, $column_name ) {
@@ -174,18 +186,21 @@ class UFSC_Licence_List_Table extends WP_List_Table {
 
     private function render_status_badge( $status ) {
         $status = strtolower( $status );
-        $class  = 'ufsc-badge ufsc-badge-default';
+        $class  = 'ufsc-badge ufsc-badge--pending';
         $label  = ucfirst( $status );
 
         if ( in_array( $status, ['validee', 'validée', 'active', 'actif'], true ) ) {
-            $class = 'ufsc-badge ufsc-badge-success';
+            $class = 'ufsc-badge ufsc-badge--ok';
             $label = __( 'Validée', 'plugin-ufsc-gestion-club-13072025' );
         } elseif ( in_array( $status, ['refusee', 'refusée', 'inactif'], true ) ) {
-            $class = 'ufsc-badge ufsc-badge-error';
+            $class = 'ufsc-badge ufsc-badge--err';
             $label = __( 'Refusée', 'plugin-ufsc-gestion-club-13072025' );
         } elseif ( in_array( $status, ['en attente', 'en_attente', 'pending'], true ) ) {
-            $class = 'ufsc-badge ufsc-badge-warning';
+            $class = 'ufsc-badge ufsc-badge--pending';
             $label = __( 'En attente', 'plugin-ufsc-gestion-club-13072025' );
+        } elseif ( in_array( $status, ['expiree', 'expirée', 'expired'], true ) ) {
+            $class = 'ufsc-badge ufsc-badge--expired';
+            $label = __( 'Expirée', 'plugin-ufsc-gestion-club-13072025' );
         }
 
         return '<span class="' . esc_attr( $class ) . '">' . esc_html( $label ) . '</span>';

--- a/includes/overrides_profix/force-shortcode-override.php
+++ b/includes/overrides_profix/force-shortcode-override.php
@@ -24,10 +24,10 @@ add_action('init', function(){
         <?php if($rows): foreach($rows as $r): $is_draft=in_array(strtolower(trim($r->statut)),array('brouillon','draft','')); ?>
           <tr>
             <td><?php echo (int)$r->id; ?></td>
-            <td><?php echo esc_html($r->nom); ?></td>
-            <td><?php echo esc_html($r->prenom); ?></td>
-            <td><?php echo esc_html($r->email); ?></td>
-            <td><?php echo $is_draft?'<span style="color:#b45309">Brouillon</span>':'<span style="color:#059669">Validée</span>'; ?></td>
+            <td class="ufsc-text-ellipsis" title="<?php echo esc_attr($r->nom); ?>"><?php echo esc_html($r->nom); ?></td>
+            <td class="ufsc-text-ellipsis" title="<?php echo esc_attr($r->prenom); ?>"><?php echo esc_html($r->prenom); ?></td>
+            <td class="ufsc-text-ellipsis" title="<?php echo esc_attr($r->email); ?>"><?php echo esc_html($r->email); ?></td>
+            <td><?php echo $is_draft?'<span class="ufsc-badge ufsc-badge--pending">Brouillon</span>':'<span class="ufsc-badge ufsc-badge--ok">Validée</span>'; ?></td>
             <td>
             <?php if($is_draft): ?>
               <button class="button ufsc-pay-licence" data-licence-id="<?php echo (int)$r->id; ?>"><?php _e('Envoyer au paiement','plugin-ufsc-gestion-club-13072025'); ?></button>

--- a/includes/views/admin-club-list.php
+++ b/includes/views/admin-club-list.php
@@ -169,7 +169,7 @@ $base_url = remove_query_arg('paged', isset($_SERVER['REQUEST_URI']) ? wp_unslas
                 </div>
             </div>
 
-            <table class="wp-list-table widefat fixed striped" id="club-table">
+            <table class="wp-list-table widefat fixed striped ufsc-table" id="club-table">
                 <thead>
                     <tr>
                         <th style="width: 40px;">
@@ -199,7 +199,7 @@ $base_url = remove_query_arg('paged', isset($_SERVER['REQUEST_URI']) ? wp_unslas
                                 <input type="checkbox" name="selected_clubs[]" value="<?php echo esc_attr($club->id); ?>" class="club-checkbox">
                             </td>
                             <td>
-                                <strong><?php echo esc_html($club->nom); ?></strong>
+                                <strong class="ufsc-text-ellipsis" title="<?php echo esc_attr($club->nom); ?>"><?php echo esc_html($club->nom); ?></strong>
                                 <?php if ($club->statut === 'Actif'): ?>
                                     <span class="dashicons dashicons-yes-alt" style="color: green;" title="Club validé"></span>
                                 <?php endif; ?>


### PR DESCRIPTION
## Summary
- add shared UI stylesheet with action container, table, badge, and ellipsis rules
- ensure club and licence lists use ellipsis and new badge classes
- show status badges with consistent styling

## Testing
- `php -l includes/views/admin-club-list.php`
- `php -l includes/licences/class-ufsc-licence-list-table.php`
- `php -l includes/overrides_profix/force-shortcode-override.php`
- `npm run build` *(fails: Invalid value for option "output.inlineDynamicImports" - multiple inputs are not supported when "output.inlineDynamicImports" is true.)*


------
https://chatgpt.com/codex/tasks/task_e_68ae9f653a14832ba2693076d7e621b7