### PR TITLE
feat: add front-end UI utilities

### DIFF
--- a/assets/js/ufsc-ui.js
+++ b/assets/js/ufsc-ui.js
@@ -1,0 +1,23 @@
+document.addEventListener('DOMContentLoaded', () => {
+  // Remove or hide empty action containers
+  document.querySelectorAll('[class]').forEach(el => {
+    const hasActionsClass = Array.from(el.classList).some(cls => cls === 'actions' || cls.endsWith('-actions'));
+    if (hasActionsClass) {
+      const hasContent = el.textContent.trim().length > 0;
+      const hasElements = el.children.length > 0;
+      if (!hasContent && !hasElements) {
+        el.remove();
+      }
+    }
+  });
+
+  // Enable sticky table headers if supported
+  if (window.CSS && CSS.supports && CSS.supports('position', 'sticky')) {
+    document.querySelectorAll('table.ufsc-table thead').forEach(thead => {
+      thead.style.position = 'sticky';
+      thead.style.top = document.body.classList.contains('admin-bar') ? '32px' : '0';
+      thead.style.background = thead.style.background || '#fff';
+      thead.style.zIndex = '1';
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add generic UI helper to hide empty action containers
- enable sticky table headers when supported

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Invalid value for option "output.inlineDynamicImports" - multiple inputs are not supported when "output.inlineDynamicImports" is true.)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9f61b554832bb73ae6643bea99ae