### PR TITLE
Include licence filter in admin licence list

### DIFF
--- a/includes/licences/admin-licence-list.php
+++ b/includes/licences/admin-licence-list.php
@@ -6,6 +6,7 @@ if (!defined('ABSPATH')) {
 require_once plugin_dir_path(__FILE__) . 'class-ufsc-licence-list-table.php';
 require_once plugin_dir_path(__FILE__) . '../helpers.php';
 require_once plugin_dir_path(__FILE__) . '../helpers/helpers-licence-status.php';
+require_once plugin_dir_path(__FILE__) . 'class-licence-filters.php';
 
 global $wpdb;
 


### PR DESCRIPTION
## Summary
- load licence filter class in admin licence list page

## Testing
- `php -l includes/licences/admin-licence-list.php`
- `phpunit` *(fails: command not found; attempted `apt-get update` but repositories are not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9345cb64832bb5ef89d5acc50f5f