### PR TITLE
Ensure proper PHP tags and close licence table file

### DIFF
--- a/includes/licences/class-ufsc-licence-list-table.php
+++ b/includes/licences/class-ufsc-licence-list-table.php
@@ -413,16 +413,6 @@ class UFSC_Licenses_List_Table extends WP_List_Table {
 
 
 
-        if ( in_array( $status, [ 'validee', 'validée', 'active', 'actif' ], true ) ) {
-            $class = 'ufsc-badge ufsc-badge-success';
-            $label = __( 'Validée', 'plugin-ufsc-gestion-club-13072025' );
-        } elseif ( in_array( $status, [ 'refusee', 'refusée', 'inactif' ], true ) ) {
-            $class = 'ufsc-badge ufsc-badge-error';
-            $label = __( 'Refusée', 'plugin-ufsc-gestion-club-13072025' );
-        } elseif ( in_array( $status, [ 'en attente', 'en_attente', 'pending' ], true ) ) {
-            $class = 'ufsc-badge ufsc-badge-warning';
-            $label = __( 'En attente', 'plugin-ufsc-gestion-club-13072025' );
-
         if ( in_array( $status, ['validee', 'validée', 'active', 'actif'], true ) ) {
             $class = 'ufsc-badge ufsc-badge--ok';
             $label = __( 'Validée', 'plugin-ufsc-gestion-club-13072025' );
@@ -435,7 +425,6 @@ class UFSC_Licenses_List_Table extends WP_List_Table {
         } elseif ( in_array( $status, ['expiree', 'expirée', 'expired'], true ) ) {
             $class = 'ufsc-badge ufsc-badge--expired';
             $label = __( 'Expirée', 'plugin-ufsc-gestion-club-13072025' );
-
         } elseif ( 'trash' === $status ) {
             $class = 'ufsc-badge ufsc-badge-default';
             $label = __( 'Corbeille', 'plugin-ufsc-gestion-club-13072025' );
@@ -444,4 +433,6 @@ class UFSC_Licenses_List_Table extends WP_List_Table {
         return '<span class="' . esc_attr( $class ) . '">' . esc_html( $label ) . '</span>';
     }
 }
+
+?>
 


### PR DESCRIPTION
## Summary
- ensure `class-ufsc-licence-list-table.php` begins with `<?php` and closes cleanly with `?>`
- fix status badge rendering logic by removing duplicate conditional block

## Testing
- `php -l includes/licences/class-ufsc-licence-list-table.php`


------
https://chatgpt.com/codex/tasks/task_e_68af021c9b0c832baf15c936e7500ccf