### PR TITLE
Add nonce verification for club search AJAX endpoint

### DIFF
--- a/includes/ajax-handlers.php
+++ b/includes/ajax-handlers.php
@@ -13,6 +13,9 @@ if (!defined('ABSPATH')) {
 
 add_action('wp_ajax_ufsc_club_search', 'ufsc_ajax_club_search');
 function ufsc_ajax_club_search() {
+    if (!check_ajax_referer('ufsc_club_search', 'nonce', false)) {
+        wp_send_json_error('Invalid nonce', 403);
+    }
     if (!current_user_can('manage_ufsc_licenses')) {
         wp_send_json_error('Unauthorized', 403);
     }

--- a/includes/licences/admin-licence-form.php
+++ b/includes/licences/admin-licence-form.php
@@ -94,6 +94,13 @@ $action_url = admin_url('admin.php?page=ufsc_license_add_admin' . ($licence_id ?
 </div>
 
 wp_enqueue_script('jquery-ui-autocomplete');
+wp_localize_script(
+    'jquery-ui-autocomplete',
+    'ufscClubSearch',
+    [
+        'nonce' => wp_create_nonce('ufsc_club_search'),
+    ]
+);
 ?>
 <div class="wrap">
 <h1><?php echo $licence_id ? esc_html__('Modifier une licence', 'plugin-ufsc-gestion-club-13072025') : esc_html__('Ajouter une licence', 'plugin-ufsc-gestion-club-13072025'); ?></h1>
@@ -138,7 +145,7 @@ wp_enqueue_script('jquery-ui-autocomplete');
 jQuery(function($){
     $('#ufsc-club-search').autocomplete({
         source: function(request, response){
-            $.getJSON(ajaxurl, {action: 'ufsc_club_search', term: request.term}, function(res){
+            $.getJSON(ajaxurl, {action: 'ufsc_club_search', term: request.term, nonce: ufscClubSearch.nonce}, function(res){
                 if (res.success) {
                     response($.map(res.data, function(item){ return { label: item.label, value: item.label, id: item.id }; }));
                 } else {


### PR DESCRIPTION
## Summary
- secure `ufsc_ajax_club_search` with `check_ajax_referer`
- expose `ufsc_club_search` nonce to autocomplete script and include it in AJAX requests

## Testing
- `phpunit` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af0d6db41c832baaead5b58a210d0e