### PR TITLE
refactor: unify capability checks

### DIFF
--- a/includes/admin/class-document-manager.php
+++ b/includes/admin/class-document-manager.php
@@ -90,7 +90,7 @@ class UFSC_Document_Manager
     private function can_access_document($club_id, $doc_type)
     {
         // Admin always has access
-        if (current_user_can('manage_ufsc')) {
+        if (current_user_can('ufsc_manage')) {
             return true;
         }
 
@@ -263,7 +263,7 @@ class UFSC_Document_Manager
     public function validate_club()
     {
         // Check permissions
-        if (!current_user_can('manage_ufsc')) {
+        if (!current_user_can('ufsc_manage')) {
             wp_send_json_error('Accès non autorisé.');
         }
 

--- a/includes/admin/class-frontend-pro-settings.php
+++ b/includes/admin/class-frontend-pro-settings.php
@@ -27,7 +27,7 @@ class UFSC_Frontend_Pro_Settings {
             'ufsc-gestion-club',
             'Frontend Pro',
             'Frontend Pro',
-            'manage_ufsc',
+            'ufsc_manage',
             'ufsc-frontend-pro',
             [__CLASS__, 'settings_page']
         );

--- a/includes/admin/class-menu.php
+++ b/includes/admin/class-menu.php
@@ -18,7 +18,7 @@ require_once plugin_dir_path(__FILE__) . '../helpers/class-ufsc-csv-export.php';
 
 // Capability used for managing UFSC licences
 if (!defined('UFSC_MANAGE_LICENSES_CAP')) {
-    define('UFSC_MANAGE_LICENSES_CAP', apply_filters('manage_ufsc_licenses', 'manage_options'));
+    define('UFSC_MANAGE_LICENSES_CAP', apply_filters('ufsc_manage_own_cap', 'ufsc_manage_own'));
 }
 
 /**
@@ -222,7 +222,7 @@ class UFSC_Menu
             'plugin-ufsc-gestion-club-13072025',
             'Ajouter une licence',
             'Ajouter une licence',
-            'manage_ufsc_licenses',
+            UFSC_MANAGE_LICENSES_CAP,
             'ufsc_license_add_admin',
             array($this, 'render_licence_add_admin_page')
 

--- a/includes/admin/class-sync-monitor.php
+++ b/includes/admin/class-sync-monitor.php
@@ -53,7 +53,7 @@ class UFSC_Sync_Monitor
             'ufsc_licenses_admin',
             'Synchronisation',
             'Synchronisation',
-            'manage_ufsc',
+            'ufsc_manage',
             'ufsc_sync_monitor',
             [$this, 'render_sync_monitor_page']
         );
@@ -518,7 +518,7 @@ class UFSC_Sync_Monitor
             return;
         }
         
-        if (!current_user_can('manage_ufsc')) {
+        if (!current_user_can('ufsc_manage')) {
             wp_send_json_error('Insufficient permissions');
             return;
         }
@@ -537,7 +537,7 @@ class UFSC_Sync_Monitor
             return;
         }
         
-        if (!current_user_can('manage_ufsc')) {
+        if (!current_user_can('ufsc_manage')) {
             wp_send_json_error(['message' => 'Insufficient permissions']);
             return;
         }

--- a/includes/admin/class-test-helper.php
+++ b/includes/admin/class-test-helper.php
@@ -50,7 +50,7 @@ class UFSC_Test_Helper
     public function test_document_system()
     {
         // Check permissions
-        if (!current_user_can('manage_ufsc')) {
+        if (!current_user_can('ufsc_manage')) {
             wp_send_json_error('Accès non autorisé.');
         }
 
@@ -223,7 +223,7 @@ class UFSC_Test_Helper
      */
     public function create_test_club()
     {
-        if (!current_user_can('manage_ufsc')) {
+        if (!current_user_can('ufsc_manage')) {
             return false;
         }
 

--- a/includes/admin/class-ufsc-admin-settings.php
+++ b/includes/admin/class-ufsc-admin-settings.php
@@ -39,7 +39,7 @@ class UFSC_Admin_Settings {
         $this->hook_suffix = add_options_page(
             __('Paramètres UFSC', 'plugin-ufsc-gestion-club-13072025'),
             __('UFSC', 'plugin-ufsc-gestion-club-13072025'),
-            'manage_ufsc',
+            'ufsc_manage',
             'ufsc-settings',
             array($this, 'render_settings_page')
         );
@@ -260,7 +260,7 @@ class UFSC_Admin_Settings {
      * Render settings page
      */
     public function render_settings_page() {
-        if (!current_user_can('manage_ufsc')) {
+        if (!current_user_can('ufsc_manage')) {
             wp_die(__('Vous n\'avez pas les permissions suffisantes pour accéder à cette page.'));
         }
         ?>

--- a/includes/admin/class-ufsc-pack-exports.php
+++ b/includes/admin/class-ufsc-pack-exports.php
@@ -18,7 +18,7 @@ class UFSC_Pack_Exports_Admin {
             'ufsc_licenses_admin', // register under UFSC menu
             __('Réglages Packs & Exports', 'plugin-ufsc-gestion-club-13072025'),
             __('Réglages & Exports', 'plugin-ufsc-gestion-club-13072025'),
-            'manage_ufsc',
+            'ufsc_manage',
             'ufsc-pack-exports',
             array($this, 'render_page')
         );
@@ -53,7 +53,7 @@ class UFSC_Pack_Exports_Admin {
     }
 
     public function export_controls() {
-        if (!current_user_can('manage_ufsc')) return;
+        if (!current_user_can('ufsc_manage')) return;
         $nonce = wp_create_nonce('ufsc_export_csv');
         ?>
         <h4><?php esc_html_e('Clubs', 'plugin-ufsc-gestion-club-13072025'); ?></h4>
@@ -108,7 +108,7 @@ class UFSC_Pack_Exports_Admin {
     }
 
     public function render_page() {
-        if (!current_user_can('manage_ufsc')) wp_die(__('Unauthorized', 'plugin-ufsc-gestion-club-13072025'));
+        if (!current_user_can('ufsc_manage')) wp_die(__('Unauthorized', 'plugin-ufsc-gestion-club-13072025'));
         ?>
         <div class="wrap ufsc-ui">
             <h1><?php esc_html_e('Réglages Packs & Exports', 'plugin-ufsc-gestion-club-13072025'); ?></h1>
@@ -142,7 +142,7 @@ class UFSC_Pack_Exports_Admin {
     }
 
     public function export_clubs_csv() {
-        if (!current_user_can('manage_ufsc')) wp_die('Forbidden');
+        if (!current_user_can('ufsc_manage')) wp_die('Forbidden');
         $nonce = isset($_POST['nonce']) ? sanitize_text_field(wp_unslash($_POST['nonce'])) : '';
         if (!wp_verify_nonce($nonce, 'ufsc_export_csv')) wp_die('Bad nonce');
         $fields = isset($_POST['fields']) ? array_map('sanitize_key', (array) $_POST['fields']) : array();
@@ -157,7 +157,7 @@ class UFSC_Pack_Exports_Admin {
     }
 
     public function export_licences_csv() {
-        if (!current_user_can('manage_ufsc')) wp_die('Forbidden');
+        if (!current_user_can('ufsc_manage')) wp_die('Forbidden');
         $nonce = isset($_POST['nonce']) ? sanitize_text_field(wp_unslash($_POST['nonce'])) : '';
         if (!wp_verify_nonce($nonce, 'ufsc_export_csv')) wp_die('Bad nonce');
         $fields = isset($_POST['fields']) ? array_map('sanitize_key', (array) $_POST['fields']) : array();

--- a/includes/admin/database-validator.php
+++ b/includes/admin/database-validator.php
@@ -113,7 +113,7 @@ function ufsc_validate_database_schema() {
  * Display validation results
  */
 function ufsc_display_validation_results() {
-    if (!current_user_can('manage_ufsc')) {
+    if (!current_user_can('ufsc_manage')) {
         wp_die('Access denied');
     }
     

--- a/includes/admin/test-sync.php
+++ b/includes/admin/test-sync.php
@@ -9,7 +9,7 @@ if (!defined('ABSPATH')) {
 }
 
 function ufsc_run_sync_tests() {
-    if (!current_user_can('manage_ufsc')) {
+    if (!current_user_can('ufsc_manage')) {
         return 'Permission denied';
     }
 
@@ -50,7 +50,7 @@ function ufsc_run_sync_tests() {
 
 // Add a admin notice to show test results when on admin pages
 add_action('admin_notices', function() {
-    if (isset($_GET['ufsc_run_tests']) && current_user_can('manage_ufsc')) {
+    if (isset($_GET['ufsc_run_tests']) && current_user_can('ufsc_manage')) {
         $results = ufsc_run_sync_tests();
         echo '<div class="notice notice-info"><p><strong>UFSC Sync Test Results:</strong></p>';
         echo '<pre>' . print_r($results, true) . '</pre></div>';

--- a/includes/admin/user-profile-enhancement.php
+++ b/includes/admin/user-profile-enhancement.php
@@ -16,7 +16,7 @@ if (!defined('ABSPATH')) {
 function ufsc_init_user_profile_hooks()
 {
     // Only add hooks if user has admin capabilities
-    if (current_user_can('manage_ufsc')) {
+    if (current_user_can('ufsc_manage')) {
         add_action('show_user_profile', 'ufsc_add_club_field_to_user_profile');
         add_action('edit_user_profile', 'ufsc_add_club_field_to_user_profile');
         add_action('personal_options_update', 'ufsc_save_user_club_association');
@@ -32,7 +32,7 @@ function ufsc_init_user_profile_hooks()
 function ufsc_add_club_field_to_user_profile($user)
 {
     // Only show for admins
-    if (!current_user_can('manage_ufsc')) {
+    if (!current_user_can('ufsc_manage')) {
         return;
     }
 
@@ -93,7 +93,7 @@ function ufsc_add_club_field_to_user_profile($user)
 function ufsc_save_user_club_association($user_id)
 {
     // Security checks
-    if (!current_user_can('manage_ufsc')) {
+    if (!current_user_can('ufsc_manage')) {
         return;
     }
 

--- a/includes/ajax-handlers.php
+++ b/includes/ajax-handlers.php
@@ -13,7 +13,7 @@ if (!defined('ABSPATH')) {
 
 add_action('wp_ajax_ufsc_club_search', 'ufsc_ajax_club_search');
 function ufsc_ajax_club_search() {
-    if (!current_user_can('manage_ufsc_licenses')) {
+    if (!current_user_can('ufsc_manage_own')) {
         wp_send_json_error('Unauthorized', 403);
     }
 
@@ -59,7 +59,7 @@ function ufsc_handle_attestation_upload() {
     }
     
     // Check user capabilities - allow club managers and admins
-    if (!current_user_can('manage_ufsc') && !current_user_can('edit_posts')) {
+    if (!current_user_can('ufsc_manage') && !current_user_can('edit_posts')) {
         wp_send_json_error([
             'message' => esc_html__('Unauthorized access.', 'ufsc-domain')
         ], 403);

--- a/includes/compat/wc-id-reconciliation.php
+++ b/includes/compat/wc-id-reconciliation.php
@@ -70,7 +70,7 @@ function ufsc_reconcile_wc_product_ids() {
     // Show admin notice if corrections were made
     if (!empty($corrections_made)) {
         add_action('admin_notices', function() use ($corrections_made) {
-            if (current_user_can('manage_ufsc')) {
+            if (current_user_can('ufsc_manage')) {
                 echo '<div class="notice notice-info is-dismissible">';
                 echo '<p><strong>Plugin UFSC:</strong> Configuration des produits WooCommerce automatiquement synchronisée :</p>';
                 echo '<ul>';

--- a/includes/controllers/save-club.php
+++ b/includes/controllers/save-club.php
@@ -47,7 +47,7 @@ function ufsc_handle_club_submission()
     }
 
     // WordPress user association handling
-    if (is_admin() && current_user_can('manage_ufsc')) {
+    if (is_admin() && current_user_can('ufsc_manage')) {
         // Admin - handle direct responsable_id assignment
         $responsable_id = isset($_POST['responsable_id']) ? intval(wp_unslash($_POST['responsable_id'])) : 0;
         

--- a/includes/core/class-gestionclub-core.php
+++ b/includes/core/class-gestionclub-core.php
@@ -50,7 +50,7 @@ class UFSC_GestionClub_Core
         add_menu_page(
             __('UFSC Clubs', 'plugin-ufsc-gestion-club-13072025'),
             __('UFSC Clubs', 'plugin-ufsc-gestion-club-13072025'),
-            'manage_ufsc',
+            'ufsc_manage',
             'ufsc-dashboard',
             [self::class, 'render_admin_page'],
             'dashicons-groups',
@@ -62,7 +62,7 @@ class UFSC_GestionClub_Core
             'ufsc-dashboard',
             __('Clubs affiliés', 'plugin-ufsc-gestion-club-13072025'),
             __('Clubs affiliés', 'plugin-ufsc-gestion-club-13072025'),
-            'manage_ufsc',
+            'ufsc_manage',
             'ufsc-clubs',
             [self::class, 'render_club_list_page']
         );
@@ -72,7 +72,7 @@ class UFSC_GestionClub_Core
             'ufsc-dashboard',
             __('Nouvelle Affiliation', 'plugin-ufsc-gestion-club-13072025'),
             __('Ajouter un club', 'plugin-ufsc-gestion-club-13072025'),
-            'manage_ufsc',
+            'ufsc_manage',
             'ufsc-ajouter-club',
             [self::class, 'render_add_club_page']
         );
@@ -84,7 +84,7 @@ class UFSC_GestionClub_Core
             'ufsc-dashboard',
             __('Paramètres', 'plugin-ufsc-gestion-club-13072025'),
             __('Paramètres', 'plugin-ufsc-gestion-club-13072025'),
-            'manage_ufsc',
+            'ufsc_manage',
             'ufsc-settings',
             [self::class, 'render_settings_page']
         );

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -394,7 +394,7 @@ function ufsc_generate_safe_navigation_button($page_type, $button_text, $button_
     }
     
     // Page not available - show disabled button or error
-    if ($show_error || current_user_can('manage_ufsc')) {
+    if ($show_error || current_user_can('ufsc_manage')) {
         $error_msg = $show_error ? '<p><small class="ufsc-error-text">' . esc_html($page_info['error']) . '</small></p>' : '';
         return '<button class="' . esc_attr($button_class) . ' ufsc-btn-disabled" disabled title="' . esc_attr($page_info['error']) . '">' 
                . esc_html($button_text) . ' (indisponible)</button>' . $error_msg;
@@ -671,7 +671,7 @@ function ufsc_get_frontend_page_alert($page_type)
     $alert_html .= '<p><strong>⚠️ Configuration requise :</strong> ';
     $alert_html .= 'La page ' . esc_html($page_name) . ' n\'est pas configurée. ';
     
-    if (current_user_can('manage_ufsc')) {
+    if (current_user_can('ufsc_manage')) {
         $settings_url = admin_url('admin.php?page=ufsc-settings');
         $alert_html .= '<a href="' . esc_url($settings_url) . '">Configurer maintenant</a>';
     } else {
@@ -710,7 +710,7 @@ add_shortcode('ufsc_page_alert', 'ufsc_page_alert_shortcode');
  */
 function ufsc_admin_page_configuration_notices()
 {
-    if (!current_user_can('manage_ufsc')) {
+    if (!current_user_can('ufsc_manage')) {
         return;
     }
 

--- a/includes/helpers/club-permissions.php
+++ b/includes/helpers/club-permissions.php
@@ -12,7 +12,7 @@ if (!function_exists('ufscsn_resolve_club_id_sanitized')) {
 
 if (!function_exists('ufscsn_require_manage_licence')) {
     function ufscsn_require_manage_licence(int $licence_id) {
-        if (!current_user_can('manage_ufsc_licenses')) {
+        if (!current_user_can('ufsc_manage_own')) {
             wp_send_json_error(__('Access denied.', 'plugin-ufsc-gestion-club-13072025'), 403);
         }
 

--- a/includes/licences/admin-licence-edit.php
+++ b/includes/licences/admin-licence-edit.php
@@ -15,7 +15,7 @@ if (!$licence_id) {
     return;
 }
 
-if (!current_user_can('ufsc_manage_licences')) {
+if (!current_user_can('ufsc_manage_own')) {
     wp_die(__('Access denied.', 'plugin-ufsc-gestion-club-13072025'));
 }
 

--- a/includes/licences/admin-licence-form.php
+++ b/includes/licences/admin-licence-form.php
@@ -3,7 +3,7 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-if (!current_user_can('manage_ufsc_licenses')) {
+if (!current_user_can('ufsc_manage_own')) {
     wp_die(__('Access denied.', 'plugin-ufsc-gestion-club-13072025'));
 }
 
@@ -64,7 +64,7 @@ function ufsc_get_club_name($club_id) {
 
 $action_url = admin_url('admin.php?page=ufsc_license_add_admin' . ($licence_id ? '&licence_id=' . $licence_id : ''));
 
-
+?>
 <div class="wrap ufsc-ui">
     <h1><?php echo esc_html("Ajouter une licence" . ($club && $club_id ? " pour le club « {$club->nom} »" : "")); ?></h1>
 

--- a/includes/licences/class-ufsc-licence-list-table.php
+++ b/includes/licences/class-ufsc-licence-list-table.php
@@ -77,7 +77,7 @@ class UFSC_Licenses_List_Table extends WP_List_Table {
         $checkbox = sprintf( '<input type="checkbox" name="licence_ids[]" value="%d" />', $item['id'] );
         $actions  = [];
 
-        if ( current_user_can( 'manage_ufsc_licenses' ) ) {
+        if ( current_user_can( 'ufsc_manage_own' ) ) {
             $view_url = wp_nonce_url(
                 admin_url( 'admin.php?page=ufsc_view_licence&id=' . $item['id'] ),
                 'ufsc_view_licence_' . $item['id']
@@ -89,7 +89,7 @@ class UFSC_Licenses_List_Table extends WP_List_Table {
             );
         }
 
-        if ( current_user_can( 'manage_ufsc_licenses' ) ) {
+        if ( current_user_can( 'ufsc_manage_own' ) ) {
             $edit_url = wp_nonce_url(
                 admin_url( 'admin.php?page=ufsc-modifier-licence&licence_id=' . $item['id'] ),
                 'ufsc_edit_licence_' . $item['id']

--- a/includes/overrides_profix/admin-ajax-validate.php
+++ b/includes/overrides_profix/admin-ajax-validate.php
@@ -9,7 +9,7 @@ function ufsc__maybe_check_nonce(){
     return true;
 }
 
-function ufsc__can_manage(){ return current_user_can('manage_ufsc_licenses')||current_user_can('manage_options')||current_user_can('edit_posts'); }
+function ufsc__can_manage(){ return current_user_can('ufsc_manage_own')||current_user_can('manage_options')||current_user_can('edit_posts'); }
 function ufsc__licences_table_and_status_col(){ global $wpdb; $t=$wpdb->prefix.'ufsc_licences'; $col=$wpdb->get_var($wpdb->prepare("SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME=%s AND COLUMN_NAME IN ('statut','status') LIMIT 1",$t)); if(!$col)$col='statut'; return array($t,$col); }
 function ufsc__set_status_fallback($id,$st){ global $wpdb; list($t,$c)=ufsc__licences_table_and_status_col(); $ok=$wpdb->update($t, array($c=>$st), array('id'=>(int)$id), array('%s'), array('%d')); return ($ok!==false); }
 function ufsc__set_status($id,$st,&$why=''){ if(!class_exists('UFSC_Licence_Manager')){ $f=dirname(__DIR__).'/licences/class-licence-manager.php'; if(file_exists($f)) require_once $f; }

--- a/includes/tests/admin-settings-test.php
+++ b/includes/tests/admin-settings-test.php
@@ -94,7 +94,7 @@ function test_ufsc_admin_settings() {
  * Display test results
  */
 function display_ufsc_admin_settings_test_results() {
-    if (!current_user_can('manage_ufsc')) {
+    if (!current_user_can('ufsc_manage')) {
         return;
     }
     
@@ -129,7 +129,7 @@ if (WP_DEBUG && is_admin()) {
     
     // Add a test link for admins
     add_action('admin_bar_menu', function($wp_admin_bar) {
-        if (current_user_can('manage_ufsc')) {
+        if (current_user_can('ufsc_manage')) {
             $wp_admin_bar->add_node([
                 'id' => 'ufsc_test_admin_settings',
                 'title' => 'Test UFSC Admin Settings',

--- a/includes/tests/database-schema-test.php
+++ b/includes/tests/database-schema-test.php
@@ -265,7 +265,7 @@ class UFSC_Database_Schema_Test
 if (defined('WP_DEBUG') && WP_DEBUG) {
     add_action('wp_loaded', function() {
         // Check user capabilities only after WordPress is fully loaded
-        if (isset($_GET['run_ufsc_schema_tests']) && ufsc_safe_current_user_can('manage_ufsc')) {
+        if (isset($_GET['run_ufsc_schema_tests']) && ufsc_safe_current_user_can('ufsc_manage')) {
             // Trigger table creation first
             if (isset($_GET['create_tables'])) {
                 UFSC_Database_Schema_Test::trigger_table_creation();

--- a/includes/tests/director-fields-test.php
+++ b/includes/tests/director-fields-test.php
@@ -214,7 +214,7 @@ class UFSC_Director_Fields_Test
 if (defined('WP_DEBUG') && WP_DEBUG) {
     add_action('wp_loaded', function() {
         // Check user capabilities only after WordPress is fully loaded
-        if (isset($_GET['run_ufsc_director_tests']) && ufsc_safe_current_user_can('manage_ufsc')) {
+        if (isset($_GET['run_ufsc_director_tests']) && ufsc_safe_current_user_can('ufsc_manage')) {
             $results = UFSC_Director_Fields_Test::run_tests();
             UFSC_Director_Fields_Test::display_results($results);
             exit;

--- a/includes/tests/frontend-refonte-test.php
+++ b/includes/tests/frontend-refonte-test.php
@@ -110,7 +110,7 @@ function ufsc_test_frontend_refonte_components() {
  * Display test results in admin
  */
 function ufsc_display_test_results() {
-    if (!current_user_can('manage_ufsc')) {
+    if (!current_user_can('ufsc_manage')) {
         return;
     }
     

--- a/includes/tests/licence-payload-test.php
+++ b/includes/tests/licence-payload-test.php
@@ -157,7 +157,7 @@ function ufsc_test_licence_payload_completeness() {
  * Run the test and output results
  */
 function ufsc_run_licence_payload_test() {
-    if (!current_user_can('manage_ufsc_licenses')) {
+    if (!current_user_can('ufsc_manage_own')) {
         return;
     }
     

--- a/includes/tests/license-form-harmonization-test.php
+++ b/includes/tests/license-form-harmonization-test.php
@@ -202,7 +202,7 @@ function ufsc_test_license_form_harmonization() {
 }
 
 // Add test to admin menu if running in admin context
-if (is_admin() && current_user_can('manage_ufsc')) {
+if (is_admin() && current_user_can('ufsc_manage')) {
     add_action('admin_menu', function() {
         add_submenu_page(
             'ufsc-gestion-club',

--- a/includes/tests/license-validation-test.php
+++ b/includes/tests/license-validation-test.php
@@ -221,7 +221,7 @@ class UFSC_License_Validation_Test
 // Run tests if accessed directly (in debug mode)
 if (WP_DEBUG && isset($_GET['test']) && $_GET['test'] === 'license_validation') {
     add_action('wp_loaded', function() {
-        if (current_user_can('manage_ufsc')) {
+        if (current_user_can('ufsc_manage')) {
             $test = new UFSC_License_Validation_Test();
             $test->run_tests();
         }

--- a/includes/tests/user-club-association-enhancement-test.php
+++ b/includes/tests/user-club-association-enhancement-test.php
@@ -152,7 +152,7 @@ function ufsc_test_user_profile_enhancement()
 }
 
 // Only run tests if explicitly requested and user has admin rights
-if (isset($_GET['run_ufsc_association_test']) && current_user_can('manage_ufsc')) {
+if (isset($_GET['run_ufsc_association_test']) && current_user_can('ufsc_manage')) {
     add_action('admin_notices', function() {
         echo '<div class="notice notice-info"><div style="padding: 10px;">';
         ufsc_test_frontend_user_association();

--- a/includes/tests/user-club-association-test.php
+++ b/includes/tests/user-club-association-test.php
@@ -168,7 +168,7 @@ function ufsc_test_user_club_association()
 }
 
 // Run the test if we're in admin context and have proper permissions
-if (is_admin() && current_user_can('manage_ufsc')) {
+if (is_admin() && current_user_can('ufsc_manage')) {
     // Only run if specifically requested via URL parameter
     if (isset($_GET['run_user_club_test']) && $_GET['run_user_club_test'] === '1') {
         add_action('admin_notices', function() {

--- a/uninstall.php
+++ b/uninstall.php
@@ -32,7 +32,7 @@ function ufsc_uninstall_cleanup() {
     global $wpdb;
     
     // Security: Only proceed if user has manage_options capability
-    if (!current_user_can('manage_ufsc')) {
+    if (!current_user_can('ufsc_manage')) {
         return;
     }
     


### PR DESCRIPTION
## Summary
- add canonical capabilities `ufsc_manage` and `ufsc_manage_own`
- map legacy capability names to new ones for backward compatibility
- update admin menu and permission checks to use new capabilities

## Testing
- `php -l Plugin_UFSC_GESTION_CLUB_13072025.php includes/admin/class-document-manager.php includes/admin/class-frontend-pro-settings.php includes/admin/class-menu.php includes/admin/class-sync-monitor.php includes/admin/class-test-helper.php includes/admin/class-ufsc-admin-settings.php includes/admin/class-ufsc-pack-exports.php includes/admin/database-validator.php includes/admin/test-sync.php includes/admin/user-profile-enhancement.php includes/ajax-handlers.php includes/compat/wc-id-reconciliation.php includes/controllers/save-club.php includes/core/class-gestionclub-core.php includes/helpers.php includes/helpers/club-permissions.php includes/licences/admin-licence-edit.php includes/licences/admin-licence-form.php includes/licences/class-ufsc-licence-list-table.php includes/overrides_profix/admin-ajax-validate.php includes/tests/admin-settings-test.php includes/tests/database-schema-test.php includes/tests/director-fields-test.php includes/tests/frontend-refonte-test.php includes/tests/licence-payload-test.php includes/tests/license-form-harmonization-test.php includes/tests/license-validation-test.php includes/tests/user-club-association-enhancement-test.php includes/tests/user-club-association-test.php uninstall.php`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af0d6f145c832b93b3c420ebf75a19