### PR TITLE
Refactor club ID resolution for non-admin users

### DIFF
--- a/Plugin_UFSC_GESTION_CLUB_13072025.php
+++ b/Plugin_UFSC_GESTION_CLUB_13072025.php
@@ -284,7 +284,8 @@ function ufsc_gestion_club_admin_enqueue_scripts($hook)
             'uploadClubNonce' => wp_create_nonce('ufsc_upload_club_attestation'),
             'deleteClubNonce' => wp_create_nonce('ufsc_delete_club_attestation'),
             'uploadLicenceNonce' => wp_create_nonce('ufsc_upload_licence_attestation'),
-            'deleteLicenceNonce' => wp_create_nonce('ufsc_delete_licence_attestation')
+            'deleteLicenceNonce' => wp_create_nonce('ufsc_delete_licence_attestation'),
+            'can_manage' => current_user_can('ufsc_manage')
         ]);
     }
 
@@ -692,7 +693,7 @@ function ufsc_handle_get_club_data() {
         return;
     }
 
-    $club_id = isset($_POST['club_id']) ? absint($_POST['club_id']) : 0;
+    $club_id = ufscsn_resolve_club_id_sanitized();
     if (!$club_id) {
         wp_send_json_error(['message' => 'Invalid club ID']);
         return;
@@ -782,6 +783,7 @@ function ufsc_gestion_club_enqueue_scripts()
     wp_localize_script('ufsc-frontend-script', 'ufsc_frontend_config', [
         'ajax_url' => admin_url('admin-ajax.php'),
         'nonce' => wp_create_nonce('ufsc_frontend_nonce'),
+        'can_manage' => current_user_can('ufsc_manage'),
         'messages' => [
             'loading' => __('Chargement...', 'plugin-ufsc-gestion-club-13072025'),
             'success' => __('Opération réussie', 'plugin-ufsc-gestion-club-13072025'),

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -33,6 +33,7 @@ jQuery(document).ready(function ($) {
         config: {
             ajaxUrl: ufsc_frontend_config?.ajax_url || '/wp-admin/admin-ajax.php',
             nonce: ufsc_frontend_config?.nonce || '',
+            canManage: ufsc_frontend_config?.can_manage || false,
             refreshInterval: 30000, // 30 seconds
             retryAttempts: 3,
             retryDelay: 1000
@@ -230,11 +231,10 @@ jQuery(document).ready(function ($) {
             $.ajax({
                 url: self.config.ajaxUrl,
                 type: 'POST',
-                data: {
+                data: Object.assign({
                     action: 'ufsc_get_club_data',
-                    club_id: clubId,
                     nonce: self.config.nonce
-                },
+                }, self.config.canManage && clubId ? { club_id: clubId } : {}),
                 success: function(response) {
                     if (response.success) {
                         self.updateUIWithFreshData(response.data.club_data);
@@ -541,7 +541,10 @@ jQuery(document).ready(function ($) {
         var $btn = jQuery(this);
         var licenceId = parseInt($btn.data('licence-id'), 10);
         var clubId = parseInt($btn.data('club-id'), 10) || 0;
-        var data = { action: 'ufsc_get_licence_pay_url', nonce: (window.ufsc_frontend_config ? ufsc_frontend_config.nonce : ''), licence_id: licenceId, club_id: clubId };
+        var data = { action: 'ufsc_get_licence_pay_url', nonce: (window.ufsc_frontend_config ? ufsc_frontend_config.nonce : ''), licence_id: licenceId };
+        if (ufsc_frontend_config && ufsc_frontend_config.can_manage && clubId) {
+            data.club_id = clubId;
+        }
         jQuery.post((window.ufsc_frontend_config ? ufsc_frontend_config.ajax_url : '/wp-admin/admin-ajax.php'), data)
             .done(function(resp){
                 if (resp && resp.success && resp.data && resp.data.url) {

--- a/assets/js/ufsc-attestations.js
+++ b/assets/js/ufsc-attestations.js
@@ -227,7 +227,9 @@
         // Prepare form data
         const formData = new FormData();
         formData.append('action', 'ufsc_attach_existing_club_attestation');
-        formData.append('club_id', clubId);
+        if (ufscAttestations.can_manage && clubId) {
+            formData.append('club_id', clubId);
+        }
         formData.append('type', type);
         formData.append('attachment_id', attachmentId);
         formData.append('nonce', ufscAttestations.uploadClubNonce);
@@ -268,7 +270,9 @@
         // Prepare form data
         const formData = new FormData();
         formData.append('action', 'ufsc_upload_club_attestation');
-        formData.append('club_id', clubId);
+        if (ufscAttestations.can_manage && clubId) {
+            formData.append('club_id', clubId);
+        }
         formData.append('type', type);
         formData.append('file', file);
         formData.append('nonce', ufscAttestations.uploadClubNonce);
@@ -308,7 +312,9 @@
         // Prepare form data
         const formData = new FormData();
         formData.append('action', 'ufsc_delete_club_attestation');
-        formData.append('club_id', clubId);
+        if (ufscAttestations.can_manage && clubId) {
+            formData.append('club_id', clubId);
+        }
         formData.append('type', type);
         formData.append('nonce', ufscAttestations.deleteClubNonce);
         

--- a/includes/frontend/club/attestations.php
+++ b/includes/frontend/club/attestations.php
@@ -269,7 +269,9 @@ function ufsc_render_custom_attestation_requests($club)
 
     $output .= '<form method="post" class="ufsc-custom-attestation-form">';
     $output .= wp_nonce_field('ufsc_request_custom_attestation', 'ufsc_custom_attestation_nonce', true, false);
-    $output .= '<input type="hidden" name="club_id" value="' . esc_attr($club->id) . '">';
+    if (current_user_can('ufsc_manage')) {
+        $output .= '<input type="hidden" name="club_id" value="' . esc_attr($club->id) . '">';
+    }
 
     $output .= '<div class="ufsc-form-row">';
     $output .= '<label for="attestation_type">Type d\'attestation demandée :</label>';
@@ -333,12 +335,15 @@ function ufsc_render_custom_attestation_requests($club)
  */
 function ufsc_get_attestation_download_url($attestation_type, $club_id)
 {
-    return add_query_arg([
+    $args = [
         'action' => 'ufsc_download_attestation',
         'type' => $attestation_type,
-        'club_id' => $club_id,
         'nonce' => wp_create_nonce('ufsc_attestation_' . $attestation_type . '_' . $club_id)
-    ], admin_url('admin-ajax.php'));
+    ];
+    if (current_user_can('ufsc_manage')) {
+        $args['club_id'] = $club_id;
+    }
+    return add_query_arg($args, admin_url('admin-ajax.php'));
 }
 
 /**
@@ -367,11 +372,14 @@ function ufsc_get_attestation_email_url($attestation_type, $club)
  */
 function ufsc_get_bulk_attestation_url($club_id)
 {
-    return add_query_arg([
+    $args = [
         'action' => 'ufsc_download_bulk_attestations',
-        'club_id' => $club_id,
         'nonce' => wp_create_nonce('ufsc_bulk_attestations_' . $club_id)
-    ], admin_url('admin-ajax.php'));
+    ];
+    if (current_user_can('ufsc_manage')) {
+        $args['club_id'] = $club_id;
+    }
+    return add_query_arg($args, admin_url('admin-ajax.php'));
 }
 
 /**
@@ -383,12 +391,15 @@ function ufsc_get_bulk_attestation_url($club_id)
  */
 function ufsc_get_licence_attestation_url($licence_id, $club_id)
 {
-    return add_query_arg([
+    $args = [
         'action' => 'ufsc_download_licence_attestation',
         'licence_id' => $licence_id,
-        'club_id' => $club_id,
         'nonce' => wp_create_nonce('ufsc_licence_attestation_' . $licence_id . '_' . $club_id)
-    ], admin_url('admin-ajax.php'));
+    ];
+    if (current_user_can('ufsc_manage')) {
+        $args['club_id'] = $club_id;
+    }
+    return add_query_arg($args, admin_url('admin-ajax.php'));
 }
 
 /**

--- a/includes/frontend/club/club-infos.php
+++ b/includes/frontend/club/club-infos.php
@@ -281,11 +281,11 @@ function ufsc_handle_contact_update($club)
         return '<div class="ufsc-alert ufsc-alert-error">Permission refusée.</div>';
     }
 
-    $club_id = intval($_POST['club_id']);
+    $club_id = ufscsn_resolve_club_id_sanitized();
     $field_name = sanitize_text_field($_POST['field_name']);
 
     // Verify club ownership
-    if ($club_id !== $club->id || !ufsc_verify_club_access($club_id)) {
+    if ($club_id !== (int) $club->id || !ufsc_verify_club_access($club_id)) {
         return '<div class="ufsc-alert ufsc-alert-error">Accès refusé.</div>';
     }
 
@@ -325,7 +325,9 @@ function ufsc_render_contact_edit_form($club)
     $output .= '<form method="post" class="ufsc-inline-form">';
     $output .= wp_nonce_field('ufsc_update_contact', 'ufsc_contact_nonce', true, false);
     $output .= '<input type="hidden" name="ufsc_update_contact_submit" value="1">';
-    $output .= '<input type="hidden" name="club_id" value="' . esc_attr($club->id) . '">';
+    if (current_user_can('ufsc_manage')) {
+        $output .= '<input type="hidden" name="club_id" value="' . esc_attr($club->id) . '">';
+    }
     $output .= '<input type="hidden" id="ufsc-edit-field-name" name="field_name" value="">';
 
     // Email field
@@ -505,19 +507,17 @@ function ufsc_render_quick_downloads($club)
     $downloads = [
         [
             'label' => 'Attestation d\'affiliation',
-            'url' => add_query_arg([
+            'url' => add_query_arg(array_merge([
                 'action' => 'attestation_affiliation',
-                'club_id' => $club->id,
                 'nonce' => wp_create_nonce('ufsc_attestation_' . $club->id)
-            ])
+            ], current_user_can('ufsc_manage') ? ['club_id' => $club->id] : []))
         ],
         [
             'label' => 'Attestation d\'assurance',
-            'url' => add_query_arg([
-                'action' => 'attestation_assurance', 
-                'club_id' => $club->id,
+            'url' => add_query_arg(array_merge([
+                'action' => 'attestation_assurance',
                 'nonce' => wp_create_nonce('ufsc_attestation_' . $club->id)
-            ])
+            ], current_user_can('ufsc_manage') ? ['club_id' => $club->id] : []))
         ]
     ];
 

--- a/includes/frontend/club/paiements.php
+++ b/includes/frontend/club/paiements.php
@@ -375,7 +375,9 @@ function ufsc_render_invoice_management($club)
     $output .= '<p>Besoin d\'une facture spécifique ou d\'un duplicata ?</p>';
     $output .= '<form method="post" class="ufsc-invoice-form">';
     $output .= wp_nonce_field('ufsc_request_invoice', 'ufsc_invoice_nonce', true, false);
-    $output .= '<input type="hidden" name="club_id" value="' . esc_attr($club->id) . '">';
+    if (current_user_can('ufsc_manage')) {
+        $output .= '<input type="hidden" name="club_id" value="' . esc_attr($club->id) . '">';
+    }
 
     $output .= '<div class="ufsc-form-row">';
     $output .= '<label for="invoice_type">Type de facture :</label>';

--- a/includes/frontend/forms/licence-form-render.php
+++ b/includes/frontend/forms/licence-form-render.php
@@ -55,12 +55,16 @@ function ufsc_render_licence_form($args = array()){
       <?php echo ufsc_nonce_field('ufsc_add_licence_nonce'); ?>
       <?php echo ufsc_nonce_field('ufsc_add_licence_to_cart', '_ufsc_licence_nonce'); ?>
       <input type="hidden" name="action" value="ufsc_submit_licence">
+      <?php if (current_user_can('ufsc_manage')): ?>
       <input type="hidden" name="club_id" value="<?php echo esc_attr($club->id); ?>">
+      <?php endif; ?>
 
       <?php wp_nonce_field('ufsc_add_licence_nonce', 'ufsc_nonce'); ?>
       <?php wp_nonce_field('ufsc_add_licence_to_cart', '_ufsc_licence_nonce'); ?>
         <input type="hidden" name="action" value="ufsc_submit_licence">
+        <?php if (current_user_can('ufsc_manage')): ?>
         <input type="hidden" name="club_id" value="<?php echo esc_attr($club->id); ?>">
+        <?php endif; ?>
 
       <input type="hidden" name="context" value="<?php echo esc_attr($args['context']); ?>">
       <?php if (!empty($prefill['id'])): ?>

--- a/includes/frontend/parts/form-licence.php
+++ b/includes/frontend/parts/form-licence.php
@@ -10,6 +10,16 @@ $clubs = $wpdb->get_results("SELECT id, nom FROM {$wpdb->prefix}ufsc_clubs ORDER
 // Get current values if editing
 $current_licence = isset($current_licence) ? $current_licence : null;
 $current_club_id = $current_licence ? $current_licence->club_id : (isset($_GET['club_id']) ? intval($_GET['club_id']) : 0);
+if (!current_user_can('ufsc_manage')) {
+    $current_club_id = (int) get_user_meta(get_current_user_id(), 'ufsc_club_id', true);
+}
+$current_club_name = '';
+foreach ($clubs as $club_tmp) {
+    if ((int) $club_tmp->id === (int) $current_club_id) {
+        $current_club_name = $club_tmp->nom;
+        break;
+    }
+}
 $is_validated = $current_licence && $current_licence->statut === 'validee';
 
 // Load regions helper
@@ -31,17 +41,21 @@ require_once plugin_dir_path(__FILE__) . '../../helpers.php';
             <!-- Club Selection -->
             <div class="ufsc-form-field">
                 <label for="club_id" class="required"><?php _e('Club', 'plugin-ufsc-gestion-club-13072025'); ?></label>
-                <select name="club_id" id="club_id" required <?php echo ($current_licence && !is_admin()) ? 'disabled' : ''; ?>>
-                    <option value=""><?php _e('Sélectionner un club', 'plugin-ufsc-gestion-club-13072025'); ?></option>
-                    <?php foreach ($clubs as $club): ?>
-                        <option value="<?php echo esc_attr($club->id); ?>" <?php selected($current_club_id, $club->id); ?>>
-                            <?php echo esc_html($club->nom); ?>
-                        </option>
-                    <?php endforeach; ?>
-                </select>
-                <?php if ($current_licence && !is_admin()): ?>
-                    <input type="hidden" name="club_id" value="<?php echo esc_attr($current_licence->club_id); ?>">
-                    <span class="help-text"><?php _e('Le club ne peut pas être modifié après création', 'plugin-ufsc-gestion-club-13072025'); ?></span>
+                <?php if (current_user_can('ufsc_manage')): ?>
+                    <select name="club_id" id="club_id" required <?php echo ($current_licence && !is_admin()) ? 'disabled' : ''; ?>>
+                        <option value=""><?php _e('Sélectionner un club', 'plugin-ufsc-gestion-club-13072025'); ?></option>
+                        <?php foreach ($clubs as $club): ?>
+                            <option value="<?php echo esc_attr($club->id); ?>" <?php selected($current_club_id, $club->id); ?>>
+                                <?php echo esc_html($club->nom); ?>
+                            </option>
+                        <?php endforeach; ?>
+                    </select>
+                    <?php if ($current_licence && !is_admin()): ?>
+                        <input type="hidden" name="club_id" value="<?php echo esc_attr($current_licence->club_id); ?>">
+                        <span class="help-text"><?php _e('Le club ne peut pas être modifié après création', 'plugin-ufsc-gestion-club-13072025'); ?></span>
+                    <?php endif; ?>
+                <?php else: ?>
+                    <span><?php echo esc_html($current_club_name); ?></span>
                 <?php endif; ?>
             </div>
             

--- a/includes/helpers/club-permissions.php
+++ b/includes/helpers/club-permissions.php
@@ -5,8 +5,17 @@ if (!defined('ABSPATH')) {
 
 if (!function_exists('ufscsn_resolve_club_id_sanitized')) {
     function ufscsn_resolve_club_id_sanitized(): int {
-        $source = $_REQUEST['club_id'] ?? 0;
-        return $source ? absint(wp_unslash($source)) : 0;
+        $user_id = get_current_user_id();
+        if (!$user_id) {
+            return 0;
+        }
+
+        if (current_user_can('ufsc_manage') && isset($_REQUEST['club_id'])) {
+            return absint(wp_unslash($_REQUEST['club_id']));
+        }
+
+        $club_id = get_user_meta($user_id, 'ufsc_club_id', true);
+        return $club_id ? absint($club_id) : 0;
     }
 }
 


### PR DESCRIPTION
## Summary
- Resolve club ID from user metadata for non-admins and restrict request overrides to ufsc_manage capability
- Pass can_manage flag to frontend scripts and omit club_id from non-admin AJAX requests and forms
- Use resolved club ID across attestation, licence, and club info features without trusting request parameters

## Testing
- `php -l includes/helpers/club-permissions.php`
- `php -l Plugin_UFSC_GESTION_CLUB_13072025.php`
- `php -l includes/frontend/club/attestations.php`
- `php -l includes/frontend/club/club-infos.php`
- `php -l includes/frontend/club/paiements.php`
- `php -l includes/frontend/forms/licence-form-render.php`
- `php -l includes/frontend/parts/form-licence.php`
- `phpunit` *(fails: command not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68af0d726ff8832b9f138a117d11482f