### PR TITLE
Sanitize WooCommerce licence form nonce

### DIFF
--- a/includes/frontend/woocommerce-licence-form.php
+++ b/includes/frontend/woocommerce-licence-form.php
@@ -90,7 +90,13 @@ function ufsc_validate_licence_fields($passed, $product_id, $quantity)
     }
 
     // Security check - verify nonce
-    if (!isset($_POST['ufsc_wc_licence_nonce']) || !wp_verify_nonce($_POST['ufsc_wc_licence_nonce'], 'ufsc_woocommerce_licence')) {
+    if (
+        !isset($_POST['ufsc_wc_licence_nonce']) ||
+        !wp_verify_nonce(
+            sanitize_text_field(wp_unslash($_POST['ufsc_wc_licence_nonce'] ?? '')),
+            'ufsc_woocommerce_licence'
+        )
+    ) {
         wc_add_notice('Erreur de sécurité. Veuillez réessayer.', 'error');
         return false;
     }


### PR DESCRIPTION
## Summary
- ensure licence form nonce is unslashed and sanitized before verification

## Testing
- `phpunit` *(fails: command not found)*
- `php -l includes/frontend/woocommerce-licence-form.php`


------
https://chatgpt.com/codex/tasks/task_e_68af15da5324832b9f545ea3fd969f33