### PR TITLE
Restrict club updates to authorized users

### DIFF
--- a/Plugin_UFSC_GESTION_CLUB_13072025.php
+++ b/Plugin_UFSC_GESTION_CLUB_13072025.php
@@ -620,6 +620,21 @@ function ufsc_handle_save_club_ajax() {
 
     try {
         if ($is_edit) {
+            // Only allow club update if the user can manage all clubs or owns this club
+            if (!current_user_can('ufsc_manage') && !ufsc_verify_club_access($club_id)) {
+                ufsc_log_operation('club_save_error', [
+                    'error'    => 'unauthorized_update_attempt',
+                    'club_id'  => $club_id,
+                    'user_id'  => get_current_user_id()
+                ]);
+
+                wp_send_json_error([
+                    'message'    => __('Accès non autorisé.', 'plugin-ufsc-gestion-club-13072025'),
+                    'error_code' => 'UNAUTHORIZED'
+                ]);
+                return;
+            }
+
             $result = $club_manager->update_club($club_id, $club_data);
             $operation = 'update';
         } else {


### PR DESCRIPTION
## Summary
- block unauthorized club edits via capability or club ownership check

## Testing
- `php -l Plugin_UFSC_GESTION_CLUB_13072025.php`
- `phpunit --version` *(command not found)*
- `npm test` *(missing script: test)*

------
https://chatgpt.com/codex/tasks/task_e_68af15d7eae0832b8fcd8e7daf81a27f