### PR TITLE
Use check_ajax_referer in licence rejection

### DIFF
--- a/Plugin_UFSC_GESTION_CLUB_13072025.php
+++ b/Plugin_UFSC_GESTION_CLUB_13072025.php
@@ -519,7 +519,7 @@ if (!function_exists('ufsc_handle_validate_licence')) {
 add_action('wp_ajax_ufsc_reject_licence', 'ufsc_handle_reject_licence');
 function ufsc_handle_reject_licence() {
     // Verify nonce first
-    if (!isset($_POST['nonce']) || !wp_verify_nonce($_POST['nonce'], 'ufsc_reject_licence')) {
+    if (!check_ajax_referer('ufsc_reject_licence', 'nonce', false)) {
         wp_send_json_error(__('Security check failed.', 'plugin-ufsc-gestion-club-13072025'), 403);
     }
 


### PR DESCRIPTION
## Summary
- sanitize and verify AJAX nonce in `ufsc_handle_reject_licence` using `check_ajax_referer`

## Testing
- `php -l Plugin_UFSC_GESTION_CLUB_13072025.php`
- `npm test` *(fails: Missing script "test")*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af15d70aa8832b8d129e79271a0887