### PR TITLE
Use check_ajax_referer for licence validation

### DIFF
--- a/Plugin_UFSC_GESTION_CLUB_13072025.php
+++ b/Plugin_UFSC_GESTION_CLUB_13072025.php
@@ -460,7 +460,7 @@ add_action('wp_ajax_ufsc_validate_licence', 'ufsc_handle_validate_licence');
 if (!function_exists('ufsc_handle_validate_licence')) {
     function ufsc_handle_validate_licence() {
         // Verify nonce first
-        if (!isset($_POST['nonce']) || !wp_verify_nonce($_POST['nonce'], 'ufsc_validate_licence')) {
+        if (!check_ajax_referer('ufsc_validate_licence', 'nonce', false)) {
             wp_send_json_error(__('Security check failed.', 'plugin-ufsc-gestion-club-13072025'), 403);
         }
 


### PR DESCRIPTION
## Summary
- use `check_ajax_referer` instead of manual nonce check in licence validation

## Testing
- `php -l Plugin_UFSC_GESTION_CLUB_13072025.php`
- `npm test` *(fails: missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af15d5cfe0832bb59a656ee7f8ee59