### PR TITLE
Update text domain for translation loading

### DIFF
--- a/Plugin_UFSC_GESTION_CLUB_13072025.php
+++ b/Plugin_UFSC_GESTION_CLUB_13072025.php
@@ -211,7 +211,7 @@ if (file_exists(UFSC_PLUGIN_PATH . 'includes/shortcodes-front.php')) {
      */
     function ufsc_gestion_club_load_textdomain() {
         load_plugin_textdomain(
-            'ufsc-domain',
+            'plugin-ufsc-gestion-club-13072025',
             false,
             dirname(plugin_basename(__FILE__)) . '/languages/'
         );


### PR DESCRIPTION
## Summary
- Use the plugin's text domain when loading translations

## Testing
- `phpunit` *(fails: command not found)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68af15d42d88832ba56202ec335fd94c