### PR TITLE
Persist additional licence fields

### DIFF
--- a/includes/controllers/licence-dirigeant-controller.php
+++ b/includes/controllers/licence-dirigeant-controller.php
@@ -49,8 +49,8 @@ function ufsc_update_dirigeant_handler()
         'delegataire'              => isset($_POST['delegataire']) ? 1 : 0,
         'numero_licence_delegataire' => sanitize_text_field(wp_unslash($_POST['numero_licence_delegataire'])),
         'note'                     => sanitize_textarea_field(wp_unslash($_POST['note'])),
-        'assurance_dom'            => isset($_POST['assurance_dom']) ? 1 : 0,
-        'assistance'               => isset($_POST['assistance']) ? 1 : 0,
+        'assurance_dommage_corporel' => isset($_POST['assurance_dommage_corporel']) ? 1 : 0,
+        'assurance_assistance'       => isset($_POST['assurance_assistance']) ? 1 : 0,
     ];
 
     // 💾 Mise à jour base de données

--- a/includes/licences/persist.php
+++ b/includes/licences/persist.php
@@ -47,6 +47,14 @@ function ufsc_persist_licence_from_post($club_id, $licence_id = 0, $extra = arra
     'infos_partenaires' => 'infos_partenaires',
     'licence_delegataire' => 'licence_delegataire',
     'numero_licence_delegataire' => 'numero_licence_delegataire',
+    'reduction_benevole' => 'reduction_benevole',
+    'reduction_postier' => 'reduction_postier',
+    'identifiant_laposte' => 'identifiant_laposte',
+    'fonction_publique' => 'fonction_publique',
+    'assurance_dommage_corporel' => 'assurance_dommage_corporel',
+    'assurance_assistance' => 'assurance_assistance',
+    'note' => 'note',
+    'is_included' => 'is_included',
   );
 
   $data = array('club_id' => (int)$club_id);
@@ -58,9 +66,9 @@ function ufsc_persist_licence_from_post($club_id, $licence_id = 0, $extra = arra
   }
 
   // Booleans
-  $bools = array('competition','diffusion_image','honorabilite','infos_fsasptt','infos_asptt','infos_cr','infos_partenaires','licence_delegataire');
+  $bools = array('competition','diffusion_image','honorabilite','infos_fsasptt','infos_asptt','infos_cr','infos_partenaires','licence_delegataire','reduction_benevole','reduction_postier','fonction_publique','assurance_dommage_corporel','assurance_assistance');
   foreach ($bools as $k){
-    if (isset($_POST[$k])) $data[$k] = !empty($_POST[$k]) ? 1 : 0;
+    $data[$k] = !empty($_POST[$k]) ? 1 : 0;
   }
 
   // Merge extras


### PR DESCRIPTION
## Summary
- map new licence fields and normalize boolean handling
- ensure reduction, assurance, and note fields are saved
- fix dirigeant controller to store insurance flags correctly

## Testing
- `php -l includes/licences/persist.php`
- `php -l includes/controllers/licence-dirigeant-controller.php`
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68af1b001108832bbfb22c92099f29d1