### PR TITLE
feat: add admin design tokens

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,3 +1,5 @@
+@import url("../src/styles/tokens.css");
+
 /* Layout général */
 .wrap {
     max-width: 1200px;

--- a/assets/css/ufsc-admin-ui.css
+++ b/assets/css/ufsc-admin-ui.css
@@ -1,3 +1,4 @@
+@import url("../src/styles/tokens.css");
 
 /* UFSC Admin UI Enhancements */
 .ufsc-wrap { max-width: 100%; }

--- a/assets/src/styles/tokens.css
+++ b/assets/src/styles/tokens.css
@@ -1,0 +1,36 @@
+:root {
+  /* Color palette */
+  --ufsc-color-primary: #2b2143;
+  --ufsc-color-primary-light: #3d2e5f;
+  --ufsc-color-primary-dark: #1e1832;
+  --ufsc-color-accent: #c8102e;
+  --ufsc-color-bg: #f7f7f7;
+  --ufsc-color-surface: #ffffff;
+  --ufsc-color-border: #e2e8f0;
+  --ufsc-color-text: #222222;
+  --ufsc-color-text-muted: #4a5568;
+
+  /* Spacing scale */
+  --ufsc-space-xs: 0.25rem;
+  --ufsc-space-sm: 0.5rem;
+  --ufsc-space-md: 1rem;
+  --ufsc-space-lg: 1.5rem;
+  --ufsc-space-xl: 2rem;
+
+  /* Radii */
+  --ufsc-radius-sm: 0.25rem;
+  --ufsc-radius-md: 0.375rem;
+  --ufsc-radius-lg: 0.5rem;
+
+  /* Typography */
+  --ufsc-font-base: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+
+  /* Transition */
+  --ufsc-transition-base: all 0.2s ease-in-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --ufsc-transition-base: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add global CSS tokens for admin interfaces
- import tokens into admin stylesheets for cascading variables
- support reduced-motion users with transition override

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Invalid value for option "output.inlineDynamicImports")

------
https://chatgpt.com/codex/tasks/task_e_68af2254b7c4832ba994a725280cd1f1