### PR TITLE
feat: add ui component utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ vendor/
 # Backup files
 *.bak
 *.backup
+!assets/dist/

--- a/assets/dist/admin.js
+++ b/assets/dist/admin.js
@@ -1,0 +1,14 @@
+import { initButtons } from '../src/components/buttons.js';
+import { initModals } from '../src/components/modal.js';
+import { showToast } from '../src/components/toast.js';
+
+window.UFSCAdmin = {
+  initButtons,
+  initModals,
+  showToast
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+  initButtons();
+  initModals();
+});

--- a/assets/src/components/badges.css
+++ b/assets/src/components/badges.css
@@ -1,0 +1,44 @@
+.ufsc-badge {
+  display: inline-block;
+  padding: 0.25rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  border: 1px solid transparent;
+}
+
+.ufsc-badge--brouillon {
+  background: var(--ufsc-color-bg-light);
+  color: var(--ufsc-color-muted);
+  border-color: var(--ufsc-color-border);
+}
+
+.ufsc-badge--en-attente {
+  background: var(--ufsc-color-warning);
+  color: #fff;
+}
+
+.ufsc-badge--validee {
+  background: var(--ufsc-color-success);
+  color: #fff;
+}
+
+.ufsc-badge--refusee {
+  background: var(--ufsc-color-accent);
+  color: #fff;
+}
+
+.ufsc-badge--expiree {
+  background: var(--ufsc-color-border);
+  color: var(--ufsc-color-text);
+}
+
+.ufsc-badge--affilie {
+  background: var(--ufsc-color-success);
+  color: #fff;
+}
+
+.ufsc-badge--suspendu {
+  background: var(--ufsc-color-accent);
+  color: #fff;
+}

--- a/assets/src/components/buttons.css
+++ b/assets/src/components/buttons.css
@@ -1,0 +1,46 @@
+.ufsc-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  border: none;
+  border-radius: 0.5rem;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  text-decoration: none;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.ufsc-btn--primary {
+  background: var(--ufsc-color-primary);
+  color: #fff;
+}
+
+.ufsc-btn--secondary {
+  background: var(--ufsc-color-bg-light);
+  color: var(--ufsc-color-text);
+  border: 1px solid var(--ufsc-color-border);
+}
+
+.ufsc-btn--subtle {
+  background: transparent;
+  color: var(--ufsc-color-primary);
+}
+
+.ufsc-btn--destructive {
+  background: var(--ufsc-color-accent);
+  color: #fff;
+}
+
+.ufsc-btn__icon {
+  display: inline-flex;
+  width: 1em;
+  height: 1em;
+  flex-shrink: 0;
+  margin-right: 0.5rem;
+}
+
+.ufsc-btn__icon--end {
+  margin-right: 0;
+  margin-left: 0.5rem;
+}

--- a/assets/src/components/buttons.js
+++ b/assets/src/components/buttons.js
@@ -1,0 +1,16 @@
+export function initButtons(root = document) {
+  const buttons = root.querySelectorAll('.ufsc-btn[data-icon]');
+  buttons.forEach(btn => {
+    const icon = btn.getAttribute('data-icon');
+    if (!icon) return;
+    const pos = btn.getAttribute('data-icon-position') || 'start';
+    const span = document.createElement('span');
+    span.className = 'ufsc-btn__icon' + (pos === 'end' ? ' ufsc-btn__icon--end' : '');
+    span.innerHTML = icon;
+    if (pos === 'end') {
+      btn.appendChild(span);
+    } else {
+      btn.insertBefore(span, btn.firstChild);
+    }
+  });
+}

--- a/assets/src/components/modal.css
+++ b/assets/src/components/modal.css
@@ -1,0 +1,21 @@
+.ufsc-modal {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0,0,0,0.5);
+  z-index: 1000;
+}
+
+.ufsc-modal[aria-hidden="false"] {
+  display: flex;
+}
+
+.ufsc-modal__dialog {
+  background: #fff;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  max-width: 90%;
+  width: 400px;
+}

--- a/assets/src/components/modal.js
+++ b/assets/src/components/modal.js
@@ -1,0 +1,67 @@
+export function initModals(root = document) {
+  const triggers = root.querySelectorAll('[data-modal-target]');
+  const modals = new Map();
+
+  triggers.forEach(trigger => {
+    const selector = trigger.getAttribute('data-modal-target');
+    const modal = root.querySelector(selector);
+    if (!modal) return;
+    if (!modals.has(modal)) {
+      setupModal(modal);
+      modals.set(modal, true);
+    }
+    trigger.addEventListener('click', e => {
+      e.preventDefault();
+      openModal(modal, trigger);
+    });
+  });
+}
+
+function setupModal(modal) {
+  modal.setAttribute('role', 'dialog');
+  modal.setAttribute('aria-modal', 'true');
+  modal.setAttribute('aria-hidden', 'true');
+  const closeBtn = modal.querySelector('[data-modal-close]');
+  if (closeBtn) {
+    closeBtn.addEventListener('click', () => closeModal(modal));
+  }
+  modal.addEventListener('click', e => {
+    if (e.target === modal) closeModal(modal);
+  });
+}
+
+function openModal(modal, trigger) {
+  modal._trigger = trigger;
+  modal._previousFocus = document.activeElement;
+  modal.setAttribute('aria-hidden', 'false');
+  trapFocus(modal);
+}
+
+function closeModal(modal) {
+  modal.setAttribute('aria-hidden', 'true');
+  document.removeEventListener('keydown', modal._trapHandler);
+  modal._previousFocus && modal._previousFocus.focus();
+}
+
+function trapFocus(modal) {
+  const focusables = modal.querySelectorAll('a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])');
+  if (!focusables.length) return;
+  const first = focusables[0];
+  const last = focusables[focusables.length - 1];
+  const handler = e => {
+    if (e.key === 'Tab') {
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    } else if (e.key === 'Escape') {
+      closeModal(modal);
+    }
+  };
+  modal._trapHandler = handler;
+  document.addEventListener('keydown', handler);
+  first.focus();
+}

--- a/assets/src/components/toast.css
+++ b/assets/src/components/toast.css
@@ -1,0 +1,21 @@
+.ufsc-toast-container {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  z-index: 1000;
+}
+
+.ufsc-toast {
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.375rem;
+  background: var(--ufsc-color-primary);
+  color: #fff;
+  box-shadow: var(--ufsc-shadow);
+}
+
+.ufsc-toast--success { background: var(--ufsc-color-success); }
+.ufsc-toast--error { background: var(--ufsc-color-accent); }
+.ufsc-toast--warning { background: var(--ufsc-color-warning); }

--- a/assets/src/components/toast.js
+++ b/assets/src/components/toast.js
@@ -1,0 +1,24 @@
+export function showToast(message, { type = 'info', duration = 4000 } = {}) {
+  let container = document.getElementById('ufsc-toast-container');
+  if (!container) {
+    container = document.createElement('div');
+    container.id = 'ufsc-toast-container';
+    container.className = 'ufsc-toast-container';
+    container.setAttribute('role', 'region');
+    container.setAttribute('aria-live', 'polite');
+    document.body.appendChild(container);
+  }
+
+  const toast = document.createElement('div');
+  toast.className = `ufsc-toast ufsc-toast--${type}`;
+  toast.setAttribute('role', 'status');
+  toast.textContent = message;
+  container.appendChild(toast);
+
+  setTimeout(() => {
+    toast.remove();
+    if (!container.children.length) {
+      container.remove();
+    }
+  }, duration);
+}


### PR DESCRIPTION
## Summary
- add button and badge component styles
- build modal and toast utilities with accessibility features
- expose component init helpers for admin pages

## Testing
- `npm test` (fails: Missing script)
- `npm run build` (fails: Invalid value for option "output.inlineDynamicImports")

------
https://chatgpt.com/codex/tasks/task_e_68af2263c2ac832ba32f29d6534dd131