### PR TITLE
Handle unauthorized access in ufsc_ajax_club_search

### DIFF
--- a/includes/ajax-handlers.php
+++ b/includes/ajax-handlers.php
@@ -15,6 +15,9 @@ add_action('wp_ajax_ufsc_club_search', 'ufsc_ajax_club_search');
 function ufsc_ajax_club_search() {
 
     if (!current_user_can('ufsc_manage_own')) {
+        wp_send_json_error('Unauthorized', 403);
+        return;
+    }
 
     if (!check_ajax_referer('ufsc_club_search', 'nonce', false)) {
         wp_send_json_error('Invalid nonce', 403);


### PR DESCRIPTION
## Summary
- ensure `ufsc_ajax_club_search` aborts with 403 when user lacks `ufsc_manage_own`
- rebalance brackets so the AJAX search handler parses correctly

## Testing
- `php -l includes/ajax-handlers.php`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af279af74c832b8ef73bc400a9b000