### PR TITLE
Remove duplicate payment_status migration query

### DIFF
--- a/includes/install/migrations.php
+++ b/includes/install/migrations.php
@@ -27,11 +27,7 @@ function ufsc_run_migrations() {
     // Add payment_status column if missing
     $col_pay = $wpdb->get_var($wpdb->prepare("SHOW COLUMNS FROM {$licences_table} LIKE %s", 'payment_status'));
     if (!$col_pay) {
-
         $wpdb->query("ALTER TABLE {$licences_table} ADD COLUMN payment_status VARCHAR(20) NOT NULL DEFAULT 'pending' AFTER order_id");
-
-        $wpdb->query("ALTER TABLE {$licences_table} ADD COLUMN payment_status VARCHAR(20) NOT NULL DEFAULT 'pending'");
-
     }
 
     // Add helpful indexes


### PR DESCRIPTION
## Summary
- remove redundant `payment_status` column migration

## Testing
- `php /tmp/migration_test.php`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af279c3e24832b89a751c3db3af0b0