### PR TITLE
chore: bump version to 20.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the UFSC Gestion Club plugin will be documented in this f
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [20.8.2] - 2025-08-27
+
+### Changed
+- Bump plugin version to 20.8.2.
+
 ## [1.3.1] - 2025-08-26
 
 ### Added

--- a/Plugin_UFSC_GESTION_CLUB_13072025.php
+++ b/Plugin_UFSC_GESTION_CLUB_13072025.php
@@ -1,11 +1,11 @@
 <?php
-define('UFSC_PLUGIN_VERSION','20.8.1');
+define('UFSC_PLUGIN_VERSION','20.8.2');
 if (!defined('UFSC_ENABLE_DIAG_ENDPOINT')) define('UFSC_ENABLE_DIAG_ENDPOINT', false);
 
 /**
  * Plugin Name: UFSC - Gestion de Club
  * Description: Plugin de gestion des affiliations et licences pour les clubs UFSC.
- * Version: 20.8.1
+ * Version: 20.8.2
  * Author: Studio Reactiv
  * Author URI: https://studioreactiv.fr
  * License: GPL v2 or later

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Plugin WordPress professionnel pour la gestion des affiliations et licences UFSC**
 
-[![Version](https://img.shields.io/badge/version-1.3.0-blue.svg)](https://github.com/DavyReactiv/Plugin_UFSC_GESTION_CLUB_13072025)
+[![Version](https://img.shields.io/badge/version-20.8.2-blue.svg)](https://github.com/DavyReactiv/Plugin_UFSC_GESTION_CLUB_13072025)
 [![WordPress](https://img.shields.io/badge/WordPress-5.5+-green.svg)](https://wordpress.org)
 [![PHP](https://img.shields.io/badge/PHP-7.4+-purple.svg)](https://php.net)
 [![License](https://img.shields.io/badge/license-GPL--2.0+-orange.svg)](LICENSE)

--- a/includes/admin/class-ufsc-admin-settings.php
+++ b/includes/admin/class-ufsc-admin-settings.php
@@ -318,7 +318,7 @@ class UFSC_Admin_Settings {
                     </p>
                     <p>
                         <strong><?php _e('Version du plugin:', 'plugin-ufsc-gestion-club-13072025'); ?></strong>
-                        <?php echo defined('UFSC_PLUGIN_VERSION') ? UFSC_PLUGIN_VERSION : '20.8.1'; ?>
+                        <?php echo defined('UFSC_PLUGIN_VERSION') ? UFSC_PLUGIN_VERSION : '20.8.2'; ?>
                     </p>
                 </div>
             </div>

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: club, management, affiliation, license, ufsc
 Requires at least: 5.5
 Tested up to: 6.8
 Requires PHP: 8.2
-Stable tag: 1.2.0
+Stable tag: 20.8.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
## Summary
- bump plugin version constants and documentation to 20.8.2
- update fallback version in admin settings
- record new version in changelog

## Testing
- `npm test` (fails: Missing script "test")
- `vendor/bin/phpunit` (fails: No such file or directory)
- `phpunit` (fails: command not found)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af2a8d5208832b880503d9ccd245e9