### PR TITLE
Fix licence list table class name

### DIFF
--- a/includes/licences/admin-licence-list.php
+++ b/includes/licences/admin-licence-list.php
@@ -130,7 +130,7 @@ if (empty($license_data['data'])) {
         '</p></div>';
 }
 
-$list_table = new UFSC_Licenses_List_Table($club_id);
+$list_table = new UFSC_Licence_List_Table($club_id);
 $list_table->set_external_data($license_data['data'], $license_data['total'], $license_data['per_page']);
 $list_table->prepare_items();
 

--- a/includes/licences/class-ufsc-licence-list-table.php
+++ b/includes/licences/class-ufsc-licence-list-table.php
@@ -7,7 +7,7 @@ if ( ! class_exists( 'WP_List_Table' ) ) {
     require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
 }
 
-class UFSC_Licenses_List_Table extends WP_List_Table {
+class UFSC_Licence_List_Table extends WP_List_Table {
     /**
      * Optional club filter passed from the page.
      *


### PR DESCRIPTION
## Summary
- fix UFSC licence list table class name
- update reference to renamed list table

## Testing
- `php -l includes/licences/class-ufsc-licence-list-table.php`
- `php -l includes/licences/admin-licence-list.php`
- `npm test` *(fails: Missing script "test")*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af30e38dcc832b85626edec5633ad0