### PR TITLE
Return array results from licence search

### DIFF
--- a/includes/licences/class-ufsc-licence-list-table.php
+++ b/includes/licences/class-ufsc-licence-list-table.php
@@ -227,8 +227,15 @@ class UFSC_Licence_List_Table extends WP_List_Table {
      */
 
     public function set_external_data($data, $total_items, $per_page) {
+        $items = array_map(
+            static function ($item) {
+                return is_object($item) ? get_object_vars($item) : $item;
+            },
+            $data
+        );
+
         $this->external_data = [
-            'items'       => array_map('get_object_vars', $data),
+            'items'       => $items,
             'total_items' => (int) $total_items,
             'per_page'    => (int) $per_page,
         ];

--- a/includes/repository/class-licence-repository.php
+++ b/includes/repository/class-licence-repository.php
@@ -262,11 +262,11 @@ class UFSC_Licence_Repository
         $offset = ((int) $args['page'] - 1) * (int) $args['per_page'];
         $params_with_limit = array_merge($params, [(int) $args['per_page'], (int) $offset]);
 
-        $list_sql = "SELECT l.*, c.nom as club_nom FROM {$this->table} l LEFT JOIN {$clubs_table} c ON l.club_id = c.id WHERE {$where_clause} ORDER BY l.date_inscription DESC LIMIT %d OFFSET %d";
+        $list_sql = "SELECT l.*, c.nom as club FROM {$this->table} l LEFT JOIN {$clubs_table} c ON l.club_id = c.id WHERE {$where_clause} ORDER BY l.date_inscription DESC LIMIT %d OFFSET %d";
         $list_query = empty($params)
             ? $this->wpdb->prepare($list_sql, (int) $args['per_page'], (int) $offset)
             : $this->wpdb->prepare($list_sql, ...$params_with_limit);
-        $items = $this->wpdb->get_results($list_query);
+        $items = $this->wpdb->get_results($list_query, ARRAY_A);
 
         return [
             'items'    => $items,


### PR DESCRIPTION
## Summary
- Return licence search results as associative arrays and include club name with consistent key
- Allow licence list table to accept preformatted array items

## Testing
- `php -l includes/repository/class-licence-repository.php`
- `php -l includes/licences/class-ufsc-licence-list-table.php`
- `phpunit` *(fails: command not found)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af51188768832bb0797824d597eb65