### PR TITLE
Fix licence edit redirect parameter

### DIFF
--- a/assets/js/ufsc-licenses-direct.js
+++ b/assets/js/ufsc-licenses-direct.js
@@ -122,7 +122,7 @@
       return;
     }
     if(act==='edit'){
-      window.location.href = '?edit_licence='+id;
+      window.location.href = '?licence_id='+id;
       return;
     }
 


### PR DESCRIPTION
## Summary
- Use `licence_id` query parameter when redirecting to edit a licence
- Confirm edit form locks fields for validated licences and AJAX handlers enforce nonce and capability checks

## Testing
- `phpunit` *(fails: command not found)*
- `apt-get install -y phpunit` *(fails: Unable to locate package phpunit)*

------
https://chatgpt.com/codex/tasks/task_e_68af5f6a4b6c832bb02df2e254024a24