### PR TITLE
Handle licence add-to-cart with club context

### DIFF
--- a/assets/js/ufsc-front.js
+++ b/assets/js/ufsc-front.js
@@ -97,20 +97,30 @@
       var $b = $(this);
       var id = $b.data('licenceId') || $b.data('licence-id');
       if(!id) return;
+      var club = $b.data('clubId') || $b.data('club-id') || (UFSC && UFSC.club_id) || '';
       lock($b, 'Ajout…');
       $.post(ajaxUrl, {
         action: 'ufsc_add_to_cart',
         licence_id: id,
-        nonce: $b.data('nonce') || (UFSC && UFSC.nonces && UFSC.nonces.add_to_cart) || ''
+        club_id: club,
+        _ajax_nonce: $b.data('nonce') || (UFSC && UFSC.nonces && UFSC.nonces.add_to_cart) || ''
       }).done(function(res){
         if(res && res.success){
-          var url = (res.data && res.data.redirect) || (window.wc_cart_url) || window.location.href;
-          if(url){ window.location.href = url; }
+          if (typeof ufscToast === 'function') {
+            ufscToast((UFSC && UFSC.i18n && UFSC.i18n.added) || 'Ajouté au panier.', 'success');
+          } else {
+            alert((UFSC && UFSC.i18n && UFSC.i18n.added) || 'Ajouté au panier.');
+          }
+          setTimeout(function(){ location.reload(); }, 800);
         } else {
-          alert((res && res.data && res.data.message) || (UFSC && UFSC.i18n && UFSC.i18n.error) || 'Erreur');
+          var msg = (res && res.data && res.data.message) || (UFSC && UFSC.i18n && UFSC.i18n.error) || 'Erreur';
+          if (typeof ufscToast === 'function') { ufscToast(msg, 'error'); }
+          else { alert(msg); }
         }
       }).fail(function(){
-        alert((UFSC && UFSC.i18n && UFSC.i18n.error) || 'Erreur');
+        var msg = (UFSC && UFSC.i18n && UFSC.i18n.error) || 'Erreur';
+        if (typeof ufscToast === 'function') { ufscToast(msg, 'error'); }
+        else { alert(msg); }
       }).always(function(){
         unlock($b);
       });

--- a/includes/overrides_profix/ajax-actions.php
+++ b/includes/overrides_profix/ajax-actions.php
@@ -13,26 +13,30 @@ function ufsc_profix_ajax_add_to_cart() {
         wp_send_json_error(esc_html__('WooCommerce requis', 'ufsc-domain'), 400);
     }
 
-    $product_id = isset($_POST['product_id']) ? absint($_POST['product_id']) : 0;
-    if (!$product_id) {
-        // fallback to defined constant
-        $product_id = defined('UFSC_LICENCE_PRODUCT_ID') ? (int) UFSC_LICENCE_PRODUCT_ID : 0;
-    }
-
+    $product_id = (int) get_option('ufsc_licence_product_id', 0);
     if (!$product_id) {
         wp_send_json_error(esc_html__('product_id requis', 'ufsc-domain'));
     }
 
-    $qty   = isset($_POST['quantity']) ? max(1, absint($_POST['quantity'])) : 1;
-    $added = WC()->cart->add_to_cart($product_id, $qty);
+    $licence_id = isset($_POST['licence_id']) ? absint($_POST['licence_id']) : 0;
+    $club_id    = isset($_POST['club_id']) ? absint($_POST['club_id']) : 0;
+    $qty        = isset($_POST['quantity']) ? max(1, absint($_POST['quantity'])) : 1;
+    $item_data  = [
+        'licence_id' => $licence_id,
+        'club_id'    => $club_id,
+    ];
+    $added = WC()->cart->add_to_cart($product_id, $qty, 0, [], $item_data);
     if (!$added) {
         wp_send_json_error(esc_html__('Ajout au panier impossible', 'ufsc-domain'));
     }
 
-    $data = [
-        'redirect' => function_exists('wc_get_cart_url') ? wc_get_cart_url() : home_url('/panier/')
-    ];
-    wp_send_json_success($data);
+    $redirect_to_checkout = get_option('ufsc_redirect_to_checkout', 'cart') === 'checkout';
+    if ($redirect_to_checkout && function_exists('wc_get_checkout_url')) {
+        $redirect = wc_get_checkout_url();
+    } else {
+        $redirect = function_exists('wc_get_cart_url') ? wc_get_cart_url() : home_url('/panier/');
+    }
+    wp_send_json_success(['redirect' => $redirect]);
 }
 add_action('wp_ajax_ufsc_add_to_cart','ufsc_profix_ajax_add_to_cart');
 add_action('wp_ajax_nopriv_ufsc_add_to_cart','ufsc_profix_ajax_add_to_cart');


### PR DESCRIPTION
## Summary
- send nonce, licence and club identifiers when adding an existing licence to cart and refresh UI with toast feedback
- attach licence and club data to WooCommerce cart item and use configured product ID with redirect URL

## Testing
- `phpunit -c tests/phpunit/phpunit.xml.dist` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af5f6877e0832b98da465965c62bb3