### PR TITLE
Use unified frontend AJAX nonce

### DIFF
--- a/assets/js/ufsc-front.js
+++ b/assets/js/ufsc-front.js
@@ -33,6 +33,7 @@
 
     var payload = $form.serializeArray();
     payload.push({name:'action', value:'ufsc_save_licence_draft'});
+    payload.push({name:'_ajax_nonce', value:(UFSC && UFSC.frontNonce) || ''});
 
     lock($btn, (window.UFSC && UFSC.i18n && UFSC.i18n.saving) || 'Enregistrement…');
 
@@ -72,6 +73,7 @@
 
     var payload = $form.serializeArray();
     payload.push({name:'action', value:'ufsc_add_licence_to_cart'});
+    payload.push({name:'_ajax_nonce', value:(UFSC && UFSC.frontNonce) || ''});
     if (window.UFSC && UFSC.nonces && UFSC.nonces.add_licence_to_cart) {
       payload.push({name:'_ufsc_licence_nonce', value:UFSC.nonces.add_licence_to_cart});
     }
@@ -101,7 +103,7 @@
       $.post(ajaxUrl, {
         action: 'ufsc_add_to_cart',
         licence_id: id,
-        nonce: $b.data('nonce') || (UFSC && UFSC.nonces && UFSC.nonces.add_to_cart) || ''
+        _ajax_nonce: (UFSC && UFSC.frontNonce) || ''
       }).done(function(res){
         if(res && res.success){
           var url = (res.data && res.data.redirect) || (window.wc_cart_url) || window.location.href;
@@ -125,7 +127,7 @@
       $.post(ajaxUrl, {
         action:'ufsc_delete_licence_draft',
         licence_id:id,
-        nonce:(UFSC && UFSC.nonces && UFSC.nonces.delete_draft) || ''
+        _ajax_nonce:(UFSC && UFSC.frontNonce) || ''
       }).done(function(res){
         if(res && res.success){ location.reload(); }
         else { alert((res && res.data && res.data.message) || 'Suppression impossible.'); }
@@ -142,7 +144,7 @@
       $.post(ajaxUrl, {
         action:'ufsc_include_quota',
         licence_id:id,
-        nonce:(UFSC && UFSC.nonces && UFSC.nonces.include_quota) || ''
+        _ajax_nonce:(UFSC && UFSC.frontNonce) || ''
       }).done(function(res){
         if(res && res.success){ location.reload(); }
         else { alert((res && res.data && res.data.message) || (UFSC && UFSC.i18n && UFSC.i18n.error) || 'Erreur'); }

--- a/includes/class-ufsc-assets.php
+++ b/includes/class-ufsc-assets.php
@@ -36,6 +36,7 @@ class UFSC_Fix_Assets {
             // Provide ajax endpoints for scripts
             'ajaxUrl' => admin_url('admin-ajax.php'),
             'ajaxurl' => admin_url('admin-ajax.php'),
+            'frontNonce' => wp_create_nonce('ufsc_front_nonce'),
             'nonces' => [
                 'add_licence_to_cart' => wp_create_nonce('ufsc_add_licence_to_cart'),
                 'add_to_cart'         => wp_create_nonce('ufsc_add_to_cart'),

--- a/includes/frontend/ajax/licence-drafts.php
+++ b/includes/frontend/ajax/licence-drafts.php
@@ -9,8 +9,7 @@ if ( ! defined('ABSPATH') ) exit;
  * Optionally accepts: licence_id (to update)
  */
 function ufsc_ajax_save_draft(){
-    $nonce = isset($_REQUEST['_ajax_nonce']) ? $_REQUEST['_ajax_nonce'] : '';
-    if ( ! wp_verify_nonce( $nonce, 'ufsc_front_nonce' ) ) {
+    if ( ! check_ajax_referer('ufsc_front_nonce', '_ajax_nonce', false) ) {
         wp_send_json_error( array('message' => esc_html__('Jeton invalide.', 'ufsc-domain')) );
     }
     if ( ! is_user_logged_in() || ! current_user_can('read') ) {
@@ -102,8 +101,7 @@ add_action('wp_ajax_nopriv_ufsc_save_licence_draft', 'ufsc_ajax_save_draft');
  * Delete a draft (only if belongs to current user's club)
  */
 function ufsc_ajax_delete_draft(){
-    $nonce = isset($_REQUEST['_ajax_nonce']) ? $_REQUEST['_ajax_nonce'] : '';
-    if ( ! wp_verify_nonce( $nonce, 'ufsc_front_nonce' ) ) {
+    if ( ! check_ajax_referer('ufsc_front_nonce', '_ajax_nonce', false) ) {
         wp_send_json_error( array('message' => esc_html__('Jeton invalide.', 'ufsc-domain')) );
     }
     if ( ! is_user_logged_in() || ! current_user_can('read') ) {

--- a/includes/frontend/ajax/quota.php
+++ b/includes/frontend/ajax/quota.php
@@ -3,8 +3,7 @@ if (!defined('ABSPATH')) exit;
 
 add_action('wp_ajax_ufsc_include_quota', 'ufsc_ajax_include_quota');
 function ufsc_ajax_include_quota(){
-    $nonce = isset($_REQUEST['_ajax_nonce']) ? $_REQUEST['_ajax_nonce'] : '';
-    if (!wp_verify_nonce($nonce, 'ufsc_front_nonce')) {
+    if ( ! check_ajax_referer('ufsc_front_nonce', '_ajax_nonce', false) ) {
         wp_send_json_error(esc_html__('Bad nonce', 'ufsc-domain'), 403);
     }
     if (!is_user_logged_in() || !current_user_can('read')) {

--- a/includes/overrides_profix/ajax-actions.php
+++ b/includes/overrides_profix/ajax-actions.php
@@ -1,8 +1,7 @@
 <?php
 if (!defined('ABSPATH')) exit;
 function ufsc_profix_ajax_add_to_cart() {
-    $nonce = isset($_REQUEST['_ajax_nonce']) ? $_REQUEST['_ajax_nonce'] : '';
-    if (!wp_verify_nonce($nonce, 'ufsc_front_nonce')) {
+    if ( ! check_ajax_referer('ufsc_front_nonce', '_ajax_nonce', false) ) {
         wp_send_json_error(esc_html__('Bad nonce', 'ufsc-domain'), 403);
     }
     if (is_user_logged_in() && !current_user_can('read')) {
@@ -38,8 +37,7 @@ add_action('wp_ajax_ufsc_add_to_cart','ufsc_profix_ajax_add_to_cart');
 add_action('wp_ajax_nopriv_ufsc_add_to_cart','ufsc_profix_ajax_add_to_cart');
 
 function ufsc_profix_ajax_save_draft() {
-    $nonce = isset($_REQUEST['_ajax_nonce']) ? $_REQUEST['_ajax_nonce'] : '';
-    if (!wp_verify_nonce($nonce, 'ufsc_front_nonce')) {
+    if ( ! check_ajax_referer('ufsc_front_nonce', '_ajax_nonce', false) ) {
         wp_send_json_error(esc_html__('Bad nonce', 'ufsc-domain'), 403);
     }
     if (!is_user_logged_in() || !current_user_can('read')) {
@@ -110,8 +108,7 @@ function ufsc_profix_ajax_save_draft() {
 add_action('wp_ajax_ufsc_save_licence_draft','ufsc_profix_ajax_save_draft');
 add_action('wp_ajax_nopriv_ufsc_save_licence_draft','ufsc_profix_ajax_save_draft');
 function ufsc_profix_ajax_delete_draft() {
-    $nonce = isset($_REQUEST['_ajax_nonce']) ? $_REQUEST['_ajax_nonce'] : '';
-    if (!wp_verify_nonce($nonce, 'ufsc_front_nonce')) {
+    if ( ! check_ajax_referer('ufsc_front_nonce', '_ajax_nonce', false) ) {
         wp_send_json_error(esc_html__('Bad nonce', 'ufsc-domain'), 403);
     }
     if (!is_user_logged_in() || !current_user_can('read')) {


### PR DESCRIPTION
## Summary
- localize unified `ufsc_front_nonce` for frontend scripts
- send `_ajax_nonce` with save draft, cart, delete draft, and quota AJAX requests
- verify nonce server-side using `check_ajax_referer`

## Testing
- `npm test` *(fails: Missing script "test")*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af5f677718832bb68e34a818b3a965