### PR TITLE
feat: add payment status badges to licences list

### DIFF
--- a/assets/css/ufsc-theme.css
+++ b/assets/css/ufsc-theme.css
@@ -219,6 +219,14 @@ html {
   background-color: var(--ufsc-warning);
 }
 
+.ufsc-badge-paid {
+  background-color: var(--ufsc-success);
+}
+
+.ufsc-badge-unpaid {
+  background-color: var(--ufsc-warning);
+}
+
 .ufsc-badge-featured {
   background-color: var(--ufsc-red);
 }

--- a/includes/frontend/club/licences.php
+++ b/includes/frontend/club/licences.php
@@ -35,7 +35,9 @@ function ufscsn_render_actions($id, $statut, $is_included, $edit_url, $cart_url,
       <?php if ($statut === 'brouillon'): ?>
         <button type="button" class="button ufsc-delete-draft" data-licence-id="<?php echo (int)$id; ?>"><?php _e('Supprimer','plugin-ufsc-gestion-club-13072025'); ?></button>
         <?php if (!in_array($payment_status, ['paid','completed'], true)): ?>
-        <button type="button" class="button button-primary ufsc-add-to-cart" data-licence-id="<?php echo (int)$id; ?>" data-nonce="<?php echo esc_attr($nonce); ?>"><?php _e('Ajouter au panier','plugin-ufsc-gestion-club-13072025'); ?></button>
+        <button type="button" class="button button-primary ufsc-add-to-cart"
+          data-licence-id="<?php echo (int)$id; ?>"
+          data-nonce="<?php echo esc_attr($nonce); ?>"><?php _e('Envoyer au panier','plugin-ufsc-gestion-club-13072025'); ?></button>
         <?php endif; ?>
         <button type="button" class="button ufsc-include-quota" data-licence-id="<?php echo (int)$id; ?>"><?php echo $is_included ? esc_html__('Retirer du quota','plugin-ufsc-gestion-club-13072025') : esc_html__('Inclure au quota','plugin-ufsc-gestion-club-13072025'); ?></button>
       <?php elseif ($statut === 'in_cart'): ?>
@@ -132,6 +134,7 @@ function ufsc_render_club_licences_list($club){
             <th class="ufsc-col--status"><?php _e('Statut','plugin-ufsc-gestion-club-13072025'); ?></th>
             <th class="ufsc-col--email"><?php _e('Email','plugin-ufsc-gestion-club-13072025'); ?></th>
             <th class="ufsc-col--date"><?php _e('Créée le','plugin-ufsc-gestion-club-13072025'); ?></th>
+            <th class="ufsc-col--payment"><?php _e('Paiement','plugin-ufsc-gestion-club-13072025'); ?></th>
             <th class="ufsc-col--actions"><?php _e('Actions','plugin-ufsc-gestion-club-13072025'); ?></th>
           </tr>
         </thead>
@@ -156,6 +159,9 @@ function ufsc_render_club_licences_list($club){
               <td class="ufsc-col--date" data-label="<?php esc_attr_e('Créée le','plugin-ufsc-gestion-club-13072025'); ?>">
                 <?php echo $r->date_creation ? esc_html( date_i18n(get_option('date_format'), strtotime($r->date_creation)) ) : '—'; ?>
               </td>
+              <td class="ufsc-col--payment" data-label="<?php esc_attr_e('Paiement','plugin-ufsc-gestion-club-13072025'); ?>">
+                <?php echo ufsc_get_payment_badge($r->payment_status ?? ''); ?>
+              </td>
               <td class="ufsc-col--actions" data-label="<?php esc_attr_e('Actions','plugin-ufsc-gestion-club-13072025'); ?>">
                 <?php
                   $edit_url = add_query_arg('licence_id', (int)$r->id, get_permalink());
@@ -166,7 +172,7 @@ function ufsc_render_club_licences_list($club){
               </td>
             </tr>
             <tr class="ufsc-row-details" data-licence-id="<?php echo (int)$r->id; ?>">
-              <td colspan="6">
+              <td colspan="7">
                 <?php
                   echo ufscsn_render_actions((int)$r->id, $stat, !empty($r->is_included), $edit_url, $cart_url, $order_id, $r->payment_status ?? '');
                 ?>

--- a/includes/helpers/helpers-licence-status.php
+++ b/includes/helpers/helpers-licence-status.php
@@ -252,8 +252,25 @@ function ufsc_register_license_status_hooks()
 ufsc_register_license_status_hooks();
 
 /**
+ * Get payment status badge HTML
+ *
+ * @param string $payment_status Payment status
+ * @return string HTML badge
+ */
+function ufsc_get_payment_badge($payment_status)
+{
+    $is_paid = in_array($payment_status, ['paid', 'completed'], true);
+    $class   = $is_paid ? 'ufsc-badge-paid' : 'ufsc-badge-unpaid';
+    $label   = $is_paid
+        ? __('Payée', 'plugin-ufsc-gestion-club-13072025')
+        : __('Non payée', 'plugin-ufsc-gestion-club-13072025');
+
+    return '<span class="ufsc-badge ' . esc_attr($class) . '">' . esc_html($label) . '</span>';
+}
+
+/**
  * Get license status badge HTML
- * 
+ *
  * @param string $status License status
  * @param string $payment_status Payment status (optional)
  * @return string HTML badge


### PR DESCRIPTION
## Summary
- add helper for rendering payment status badges
- display payment column in licence list and adjust actions button
- style payment badges in theme CSS

## Testing
- `php -l includes/helpers/helpers-licence-status.php`
- `php -l includes/frontend/club/licences.php`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af5f6a7ec4832b9b8ca5d93b1e5448