### PR TITLE
feat: display payment status badge for licences

### DIFF
--- a/assets/css/ufsc-theme.css
+++ b/assets/css/ufsc-theme.css
@@ -254,11 +254,12 @@ html {
 /* ===== BADGES ===== */
 .ufsc-badge {
   display: inline-block;
-  padding: 4px 8px;
-  border-radius: 4px;
+  padding: 0.25em 0.5em;
+  border-radius: 12px;
   font-size: 12px;
   font-weight: 600;
-  color: white;
+  color: #fff;
+  line-height: 1;
 }
 
 .ufsc-badge-active {
@@ -278,7 +279,7 @@ html {
 }
 
 .ufsc-badge-unpaid {
-  background-color: var(--ufsc-warning);
+  background-color: var(--ufsc-color-accent);
 }
 
 .ufsc-badge-featured {

--- a/includes/frontend/club/licences.php
+++ b/includes/frontend/club/licences.php
@@ -34,7 +34,7 @@ function ufscsn_render_actions($id, $statut, $is_included, $edit_url, $cart_url,
       <a class="button button-secondary" title="<?php esc_attr_e('Modifier','plugin-ufsc-gestion-club-13072025'); ?>" href="<?php echo esc_url($edit_url); ?>"><?php _e('Modifier','plugin-ufsc-gestion-club-13072025'); ?></a>
       <?php if ($statut === 'brouillon'): ?>
         <button type="button" class="button ufsc-delete-draft" data-licence-id="<?php echo (int)$id; ?>"><?php _e('Supprimer','plugin-ufsc-gestion-club-13072025'); ?></button>
-        <?php if (!in_array($payment_status, ['paid','completed'], true)): ?>
+        <?php if (!ufsc_is_payment_paid($payment_status)): ?>
         <button type="button" class="button button-primary ufsc-add-to-cart"
           data-licence-id="<?php echo (int)$id; ?>"
           data-nonce="<?php echo esc_attr($nonce); ?>"><?php _e('Envoyer au panier','plugin-ufsc-gestion-club-13072025'); ?></button>

--- a/includes/helpers/helpers-licence-status.php
+++ b/includes/helpers/helpers-licence-status.php
@@ -257,15 +257,20 @@ ufsc_register_license_status_hooks();
  * @param string $payment_status Payment status
  * @return string HTML badge
  */
+function ufsc_is_payment_paid($payment_status)
+{
+    return in_array($payment_status, ['paid', 'completed'], true);
+}
+
 function ufsc_get_payment_badge($payment_status)
 {
-    $is_paid = in_array($payment_status, ['paid', 'completed'], true);
+    $is_paid = ufsc_is_payment_paid($payment_status);
     $class   = $is_paid ? 'ufsc-badge-paid' : 'ufsc-badge-unpaid';
     $label   = $is_paid
-        ? __('Payée', 'plugin-ufsc-gestion-club-13072025')
-        : __('Non payée', 'plugin-ufsc-gestion-club-13072025');
+        ? esc_html__('Payée', 'plugin-ufsc-gestion-club-13072025')
+        : esc_html__('Non payée', 'plugin-ufsc-gestion-club-13072025');
 
-    return '<span class="ufsc-badge ' . esc_attr($class) . '">' . esc_html($label) . '</span>';
+    return '<span class="ufsc-badge ' . esc_attr($class) . '">' . $label . '</span>';
 }
 
 /**


### PR DESCRIPTION
## Summary
- show payment badges for each licence and only allow cart submission when unpaid
- style payment badges with pill-shaped background and accent color

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`
- `phpunit` (fails: command not found)
- `vendor/bin/phpunit` (fails: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_68af67485288832bb26a5b0b9e7ef28b