### PR TITLE
Use unified front nonce for front-end AJAX

### DIFF
--- a/assets/js/ufsc-front.js
+++ b/assets/js/ufsc-front.js
@@ -128,7 +128,7 @@
         action: 'ufsc_add_to_cart',
         licence_id: id,
         club_id: club,
-        _ajax_nonce: $b.data('nonce') || (UFSC && UFSC.nonces && UFSC.nonces.add_to_cart) || ''
+        _ajax_nonce: (UFSC && UFSC.frontNonce) || ''
       }).done(function(res){
         if(res && res.success){
           var msg = (UFSC && UFSC.i18n && UFSC.i18n.added) || 'Ajouté au panier.';

--- a/includes/frontend/ajax/licence-drafts.php
+++ b/includes/frontend/ajax/licence-drafts.php
@@ -9,9 +9,7 @@ if ( ! defined('ABSPATH') ) exit;
  * Optionally accepts: licence_id (to update)
  */
 function ufsc_ajax_save_draft(){
-    if ( ! check_ajax_referer('ufsc_front_nonce', '_ajax_nonce', false) ) {
-        wp_send_json_error( array('message' => esc_html__('Jeton invalide.', 'ufsc-domain')) );
-    }
+    check_ajax_referer('ufsc_front_nonce');
     if ( ! is_user_logged_in() || ! current_user_can('read') ) {
         wp_send_json_error( array('message' => esc_html__('Connexion requise.', 'ufsc-domain')) ,401);
     }
@@ -101,9 +99,7 @@ add_action('wp_ajax_nopriv_ufsc_save_licence_draft', 'ufsc_ajax_save_draft');
  * Delete a draft (only if belongs to current user's club)
  */
 function ufsc_ajax_delete_draft(){
-    if ( ! check_ajax_referer('ufsc_front_nonce', '_ajax_nonce', false) ) {
-        wp_send_json_error( array('message' => esc_html__('Jeton invalide.', 'ufsc-domain')) );
-    }
+    check_ajax_referer('ufsc_front_nonce');
     if ( ! is_user_logged_in() || ! current_user_can('read') ) {
         wp_send_json_error( array('message' => esc_html__('Connexion requise.', 'ufsc-domain')) ,401);
     }

--- a/includes/frontend/ajax/quota.php
+++ b/includes/frontend/ajax/quota.php
@@ -3,9 +3,7 @@ if (!defined('ABSPATH')) exit;
 
 add_action('wp_ajax_ufsc_include_quota', 'ufsc_ajax_include_quota');
 function ufsc_ajax_include_quota(){
-    if ( ! check_ajax_referer('ufsc_front_nonce', '_ajax_nonce', false) ) {
-        wp_send_json_error(esc_html__('Bad nonce', 'ufsc-domain'), 403);
-    }
+    check_ajax_referer('ufsc_front_nonce');
     if (!is_user_logged_in() || !current_user_can('read')) {
         wp_send_json_error(esc_html__('Non connecté', 'ufsc-domain'), 401);
     }

--- a/includes/overrides_profix/ajax-actions.php
+++ b/includes/overrides_profix/ajax-actions.php
@@ -1,9 +1,7 @@
 <?php
 if (!defined('ABSPATH')) exit;
 function ufsc_profix_ajax_add_to_cart() {
-    if ( ! check_ajax_referer('ufsc_front_nonce', '_ajax_nonce', false) ) {
-        wp_send_json_error(esc_html__('Bad nonce', 'ufsc-domain'), 403);
-    }
+    check_ajax_referer('ufsc_front_nonce');
     if (is_user_logged_in() && !current_user_can('read')) {
         wp_send_json_error(esc_html__('Non autorisé', 'ufsc-domain'), 403);
     }
@@ -41,9 +39,7 @@ add_action('wp_ajax_ufsc_add_to_cart','ufsc_profix_ajax_add_to_cart');
 add_action('wp_ajax_nopriv_ufsc_add_to_cart','ufsc_profix_ajax_add_to_cart');
 
 function ufsc_profix_ajax_save_draft() {
-    if ( ! check_ajax_referer('ufsc_front_nonce', '_ajax_nonce', false) ) {
-        wp_send_json_error(esc_html__('Bad nonce', 'ufsc-domain'), 403);
-    }
+    check_ajax_referer('ufsc_front_nonce');
     if (!is_user_logged_in() || !current_user_can('read')) {
         wp_send_json_error(esc_html__('Connexion requise', 'ufsc-domain'));
     }
@@ -112,9 +108,7 @@ function ufsc_profix_ajax_save_draft() {
 add_action('wp_ajax_ufsc_save_licence_draft','ufsc_profix_ajax_save_draft');
 add_action('wp_ajax_nopriv_ufsc_save_licence_draft','ufsc_profix_ajax_save_draft');
 function ufsc_profix_ajax_delete_draft() {
-    if ( ! check_ajax_referer('ufsc_front_nonce', '_ajax_nonce', false) ) {
-        wp_send_json_error(esc_html__('Bad nonce', 'ufsc-domain'), 403);
-    }
+    check_ajax_referer('ufsc_front_nonce');
     if (!is_user_logged_in() || !current_user_can('read')) {
         wp_send_json_error(esc_html__('Connexion requise', 'ufsc-domain'));
     }


### PR DESCRIPTION
## Summary
- send UFSC.frontNonce as `_ajax_nonce` for add-to-cart button requests
- secure quota and licence draft endpoints with `check_ajax_referer('ufsc_front_nonce')`

## Testing
- `npm test` *(fails: npm: No such file or directory)*
- `php -l includes/frontend/ajax/quota.php` *(fails: php: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68af69e75c1c832b9eadaa1a9b5f9f72