### PR TITLE
feat: improve licence cart ajax

### DIFF
--- a/assets/js/ufsc-front.js
+++ b/assets/js/ufsc-front.js
@@ -123,12 +123,13 @@
       var id = $b.data('licenceId') || $b.data('licence-id');
       if(!id) return;
       var club = $b.data('clubId') || $b.data('club-id') || (UFSC && UFSC.club_id) || '';
+      var nonce = (UFSC && (UFSC.frontNonce || (UFSC.nonces && UFSC.nonces.add_to_cart))) || '';
       lock($b, 'Ajout…');
       $.post(ajaxUrl, {
         action: 'ufsc_add_to_cart',
         licence_id: id,
         club_id: club,
-        _ajax_nonce: $b.data('nonce') || (UFSC && UFSC.nonces && UFSC.nonces.add_to_cart) || ''
+        _ajax_nonce: nonce
       }).done(function(res){
         if(res && res.success){
           var msg = (UFSC && UFSC.i18n && UFSC.i18n.added) || 'Ajouté au panier.';
@@ -137,7 +138,16 @@
           } else {
             notifySuccess(msg);
           }
-          setTimeout(function(){ location.reload(); }, 800);
+          var $row = $b.closest('tr.ufsc-row');
+          if(res.data){
+            if(res.data.payment_badge){
+              $row.find('.ufsc-col--payment').html(res.data.payment_badge);
+            }
+            if(res.data.redirect){
+              var viewTxt = (UFSC && UFSC.i18n && UFSC.i18n.view_cart) || 'Voir panier';
+              $row.find('.ufsc-col--actions').html('<a class="button" href="'+res.data.redirect+'">'+viewTxt+'</a>');
+            }
+          }
         } else {
           notifyError((res && res.data && res.data.message) || (UFSC && UFSC.i18n && UFSC.i18n.error) || 'Erreur');
         }

--- a/includes/overrides_profix/ajax-actions.php
+++ b/includes/overrides_profix/ajax-actions.php
@@ -35,7 +35,16 @@ function ufsc_profix_ajax_add_to_cart() {
     } else {
         $redirect = function_exists('wc_get_cart_url') ? wc_get_cart_url() : home_url('/panier/');
     }
-    wp_send_json_success(['redirect' => $redirect]);
+
+    $payment_badge = '';
+    if (function_exists('ufsc_get_payment_badge')) {
+        $payment_badge = ufsc_get_payment_badge('pending');
+    }
+
+    wp_send_json_success([
+        'redirect'      => $redirect,
+        'payment_badge' => $payment_badge,
+    ]);
 }
 add_action('wp_ajax_ufsc_add_to_cart','ufsc_profix_ajax_add_to_cart');
 add_action('wp_ajax_nopriv_ufsc_add_to_cart','ufsc_profix_ajax_add_to_cart');


### PR DESCRIPTION
## Summary
- send licence id, club id, and nonce when adding a licence to cart and update payment badge on success
- handle cart addition server-side using optioned product id and return redirect plus badge markup

## Testing
- `php -l includes/overrides_profix/ajax-actions.php`
- `npm run build`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af69e65f14832b8c27464eb95b7341