### PR TITLE
Support legacy licence edit param and add AJAX save tests

### DIFF
--- a/assets/js/ufsc-licenses-direct.js
+++ b/assets/js/ufsc-licenses-direct.js
@@ -144,6 +144,7 @@
       return;
     }
     if(act==='edit'){
+      // Use canonical query param for edition (replaces legacy ?edit_licence=)
       window.location.href = '?licence_id='+id;
       return;
     }

--- a/includes/licences/admin-licence-edit.php
+++ b/includes/licences/admin-licence-edit.php
@@ -9,7 +9,14 @@ require_once UFSC_PLUGIN_PATH . 'includes/licences/class-ufsc-licenses-repositor
 require_once UFSC_PLUGIN_PATH . 'includes/licences/validation.php';
 
 global $wpdb;
-$licence_id = isset($_GET['licence_id']) ? intval(wp_unslash($_GET['licence_id'])) : 0;
+// Support legacy ?edit_licence= parameter while preferring ?licence_id=
+if (isset($_GET['licence_id'])) {
+    $licence_id = intval(wp_unslash($_GET['licence_id']));
+} elseif (isset($_GET['edit_licence'])) {
+    $licence_id = intval(wp_unslash($_GET['edit_licence']));
+} else {
+    $licence_id = 0;
+}
 
 if (!$licence_id) {
     echo '<div class="notice notice-error"><p>Aucune licence sélectionnée.</p></div>';

--- a/tests/phpunit/test-ajax-save-draft.php
+++ b/tests/phpunit/test-ajax-save-draft.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Tests for AJAX licence draft saving
+ */
+class Test_Ajax_Save_Draft extends WP_UnitTestCase {
+    /**
+     * Helper to perform AJAX save call and return decoded JSON response.
+     */
+    protected function call_save( $user_id, $club_id, $nonce ) {
+        wp_set_current_user( $user_id );
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_POST = [
+            'nonce'         => $nonce,
+            'club_id'       => $club_id,
+            'nom'           => 'Test',
+            'prenom'        => 'User',
+            'date_naissance'=> '2000-01-01',
+            'email'         => 'test@example.com',
+            'adresse'       => '1 rue',
+            'code_postal'   => '75000',
+            'ville'         => 'Paris',
+            'tel_mobile'    => '0600000000',
+            'competition'   => 0,
+        ];
+        try {
+            ufsc_handle_save_licence_draft();
+        } catch ( \Exception $e ) {
+            return json_decode( $e->getMessage(), true );
+        }
+        return null;
+    }
+
+    public function test_nonce_and_capability_checks() {
+        if ( ! class_exists( 'UFSC_Club_Manager' ) ) {
+            $this->markTestSkipped( 'UFSC plugin classes not available' );
+        }
+        $club_manager = UFSC_Club_Manager::get_instance();
+        $club_id = $club_manager->add_club( [ 'nom' => 'Ajax Club', 'email' => 'ajax@example.com' ] );
+
+        // Authorized user with valid nonce
+        $admin_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+        update_user_meta( $admin_id, 'ufsc_club_id', $club_id );
+        $res = $this->call_save( $admin_id, $club_id, wp_create_nonce( 'ufsc_frontend_nonce' ) );
+        $this->assertTrue( $res['success'] );
+        $this->assertArrayHasKey( 'licence_id', $res['data'] );
+
+        // Invalid nonce
+        $res = $this->call_save( $admin_id, $club_id, 'bad_nonce' );
+        $this->assertFalse( $res['success'] );
+
+        // Unauthorized user
+        $user_id = $this->factory->user->create( [ 'role' => 'subscriber' ] );
+        $res = $this->call_save( $user_id, $club_id, wp_create_nonce( 'ufsc_frontend_nonce' ) );
+        $this->assertFalse( $res['success'] );
+    }
+}


### PR DESCRIPTION
## Summary
- handle deprecated `edit_licence` query parameter while directing edits through `licence_id`
- document canonical licence edit param in client script
- cover AJAX licence draft saving with nonce and capability checks

## Testing
- `phpunit -q tests/phpunit/test-ajax-save-draft.php` *(fails: phpunit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68af69e0debc832baa2723cd4108a99f