### PR TITLE
Fix licence add-to-cart AJAX payload and validation

### DIFF
--- a/assets/js/ufsc-front.js
+++ b/assets/js/ufsc-front.js
@@ -129,11 +129,7 @@
         action: 'ufsc_add_to_cart',
         licence_id: id,
         club_id: club,
-
         _ajax_nonce: nonce
-
-        _ajax_nonce: (UFSC && UFSC.frontNonce) || ''
-
       }).done(function(res){
         if(res && res.success){
           var msg = (UFSC && UFSC.i18n && UFSC.i18n.added) || 'Ajouté au panier.';

--- a/includes/overrides_profix/ajax-actions.php
+++ b/includes/overrides_profix/ajax-actions.php
@@ -17,8 +17,12 @@ function ufsc_profix_ajax_add_to_cart() {
 
     $licence_id = isset($_POST['licence_id']) ? absint($_POST['licence_id']) : 0;
     $club_id    = isset($_POST['club_id']) ? absint($_POST['club_id']) : 0;
-    $qty        = isset($_POST['quantity']) ? max(1, absint($_POST['quantity'])) : 1;
-    $item_data  = [
+    if (!$licence_id || !$club_id) {
+        wp_send_json_error(esc_html__('Paramètres manquants', 'ufsc-domain'));
+    }
+
+    $qty       = isset($_POST['quantity']) ? max(1, absint($_POST['quantity'])) : 1;
+    $item_data = [
         'licence_id' => $licence_id,
         'club_id'    => $club_id,
     ];


### PR DESCRIPTION
## Summary
- ensure licence add-to-cart ajax sends nonce, licence_id and club_id
- validate licence and club IDs in PHP and pass metadata to `WC()->cart->add_to_cart`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af6d4aabd4832bafc31cb44a28b373