### PR TITLE
Use unified AJAX nonce for front actions

### DIFF
--- a/assets/js/ufsc-front.js
+++ b/assets/js/ufsc-front.js
@@ -97,9 +97,6 @@
     var payload = $form.serializeArray();
     payload.push({name:'action', value:'ufsc_add_licence_to_cart'});
     payload.push({name:'_ajax_nonce', value:(UFSC && UFSC.frontNonce) || ''});
-    if (window.UFSC && UFSC.nonces && UFSC.nonces.add_licence_to_cart) {
-      payload.push({name:'_ufsc_licence_nonce', value:UFSC.nonces.add_licence_to_cart});
-    }
 
     $.post(ajaxUrl, payload).done(function(res){
       if(res && res.success){
@@ -122,19 +119,14 @@
       var $b = $(this);
       var id = $b.data('licenceId') || $b.data('licence-id');
       if(!id) return;
-      var club = $b.data('clubId') || $b.data('club-id') || (UFSC && UFSC.club_id) || '';
-      var nonce = (UFSC && (UFSC.frontNonce || (UFSC.nonces && UFSC.nonces.add_to_cart))) || '';
-      lock($b, 'Ajout…');
-      $.post(ajaxUrl, {
-        action: 'ufsc_add_to_cart',
-        licence_id: id,
-        club_id: club,
-
-        _ajax_nonce: nonce
-
-        _ajax_nonce: (UFSC && UFSC.frontNonce) || ''
-
-      }).done(function(res){
+        var club = $b.data('clubId') || $b.data('club-id') || (UFSC && UFSC.club_id) || '';
+        lock($b, 'Ajout…');
+        $.post(ajaxUrl, {
+          action: 'ufsc_add_to_cart',
+          licence_id: id,
+          club_id: club,
+          _ajax_nonce: (UFSC && UFSC.frontNonce) || ''
+        }).done(function(res){
         if(res && res.success){
           var msg = (UFSC && UFSC.i18n && UFSC.i18n.added) || 'Ajouté au panier.';
           if (typeof ufscToast === 'function') {

--- a/includes/class-ufsc-assets.php
+++ b/includes/class-ufsc-assets.php
@@ -37,12 +37,6 @@ class UFSC_Fix_Assets {
             'ajaxUrl' => admin_url('admin-ajax.php'),
             'ajaxurl' => admin_url('admin-ajax.php'),
             'frontNonce' => wp_create_nonce('ufsc_front_nonce'),
-            'nonces' => [
-                'add_licence_to_cart' => wp_create_nonce('ufsc_add_licence_to_cart'),
-                'add_to_cart'         => wp_create_nonce('ufsc_add_to_cart'),
-                'delete_draft'        => wp_create_nonce('ufsc_delete_licence_draft'),
-                'include_quota'       => wp_create_nonce('ufsc_include_quota'),
-            ],
             'i18n' => [
                 'saving' => __('Enregistrement…','plugin-ufsc-gestion-club-13072025'),
                 'saved'  => __('Brouillon enregistré.','plugin-ufsc-gestion-club-13072025'),


### PR DESCRIPTION
## Summary
- Localize a single `ufsc_front_nonce` and pass it as `_ajax_nonce` for all front-end AJAX calls
- Streamline front-end asset handling to rely on the unified nonce

## Testing
- `phpunit -c tests/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af6d564778832b86cca60e4bee2678