### PR TITLE
Use canonical licence_id param for editing licences

### DIFF
--- a/assets/js/ufsc-licenses-direct.js
+++ b/assets/js/ufsc-licenses-direct.js
@@ -144,8 +144,8 @@
       return;
     }
     if(act==='edit'){
-      // Use canonical query param for edition (replaces legacy ?edit_licence=)
-      window.location.href = '?licence_id='+id;
+      // Redirect to the edit page using the canonical licence_id parameter
+      window.location.href = '?licence_id=' + encodeURIComponent(id);
       return;
     }
 
@@ -196,13 +196,6 @@
       a.href = URL.createObjectURL(blob); a.download='licences.csv'; a.click();
     });
   }
-
-  tbody.addEventListener('click',e=>{
-    const btn = e.target.closest('button[data-a="view"]');
-    if(!btn) return;
-    const id = btn.getAttribute('data-id');
-    if(id) window.location.href = `?view_licence=${id}`;
-  });
 
   render();
 })();


### PR DESCRIPTION
## Summary
- Redirect edit buttons using the canonical `licence_id` parameter
- Drop redundant click handler in licence list table

## Testing
- `phpunit tests/phpunit/test-ajax-save-draft.php` *(fails: command not found)*
- `./vendor/bin/phpunit tests/phpunit/test-ajax-save-draft.php` *(fails: no such file or directory)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68af6d4974cc832b88752746112aa4b1