### PR TITLE
Assign DataTable ID to club license list

### DIFF
--- a/includes/licences/admin-licence-list.php
+++ b/includes/licences/admin-licence-list.php
@@ -229,6 +229,7 @@ $export_nonce = wp_create_nonce('ufsc_export_licences_' . $club_id);
             ob_start();
             $list_table->display();
             $table_html = ob_get_clean();
+            $table_html = str_replace( '<table', '<table id="licenses-table-club"', $table_html );
             $table_html = str_replace( 'wp-list-table widefat fixed striped', 'ufsc-table', $table_html );
             $table_html = preg_replace( '/<tr(?! class=)/', '<tr class="ufsc-row"', $table_html );
             echo $table_html;


### PR DESCRIPTION
## Summary
- ensure club license list table carries `licenses-table-club` id for DataTables targeting
- confirmed DataTables config continues to reference `#licenses-table-club`

## Testing
- `php -l includes/licences/admin-licence-list.php`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af79d42d04832bbc75ba7d45e80cae