### PR TITLE
Alias is_included as quota in licence search results

### DIFF
--- a/includes/licences/class-ufsc-licence-list-table.php
+++ b/includes/licences/class-ufsc-licence-list-table.php
@@ -159,7 +159,7 @@ class UFSC_Licence_List_Table extends WP_List_Table {
             case 'categorie':
                 return esc_html( $item['categorie'] );
             case 'quota':
-                return $item['quota'] ? __( 'Oui', 'plugin-ufsc-gestion-club-13072025' ) : __( 'Non', 'plugin-ufsc-gestion-club-13072025' );
+                return !empty( $item['quota'] ) ? __( 'Oui', 'plugin-ufsc-gestion-club-13072025' ) : __( 'Non', 'plugin-ufsc-gestion-club-13072025' );
             case 'statut':
                 return $this->render_status_badge( $item['statut'], $item['payment_status'] ?? '' );
             case 'date_licence':
@@ -229,7 +229,11 @@ class UFSC_Licence_List_Table extends WP_List_Table {
     public function set_external_data($data, $total_items, $per_page) {
         $items = array_map(
             static function ($item) {
-                return is_object($item) ? get_object_vars($item) : $item;
+                $item = is_object($item) ? get_object_vars($item) : $item;
+                if (isset($item['is_included']) && !isset($item['quota'])) {
+                    $item['quota'] = $item['is_included'];
+                }
+                return $item;
             },
             $data
         );

--- a/includes/repository/class-licence-repository.php
+++ b/includes/repository/class-licence-repository.php
@@ -262,7 +262,7 @@ class UFSC_Licence_Repository
         $offset           = ((int) $args['page'] - 1) * (int) $args['per_page'];
         $params_with_limit = array_merge($params, [(int) $args['per_page'], (int) $offset]);
 
-        $list_sql   = "SELECT l.*, c.nom as club FROM {$this->table} l LEFT JOIN {$clubs_table} c ON l.club_id = c.id WHERE {$where_clause} ORDER BY l.date_inscription DESC LIMIT %d OFFSET %d";
+        $list_sql   = "SELECT l.*, l.is_included AS quota, c.nom AS club FROM {$this->table} l LEFT JOIN {$clubs_table} c ON l.club_id = c.id WHERE {$where_clause} ORDER BY l.date_inscription DESC LIMIT %d OFFSET %d";
         $list_query = empty($params)
             ? $this->wpdb->prepare($list_sql, (int) $args['per_page'], (int) $offset)
             : $this->wpdb->prepare($list_sql, ...$params_with_limit);


### PR DESCRIPTION
## Summary
- Alias `is_included` to `quota` in licence repository search queries
- Normalize search results so list table always reads from `quota`

## Testing
- `php -l includes/repository/class-licence-repository.php`
- `php -l includes/licences/class-ufsc-licence-list-table.php`
- `phpunit` *(fails: command not found)*
- `composer global require phpunit/phpunit:^9 --no-interaction` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68af80bca8d8832ba341acc4e5ccf8d4