### PR TITLE
Ensure licence list table supplies date_licence field

### DIFF
--- a/includes/licences/class-ufsc-licence-list-table.php
+++ b/includes/licences/class-ufsc-licence-list-table.php
@@ -230,6 +230,9 @@ class UFSC_Licence_List_Table extends WP_List_Table {
         $items = array_map(
             static function ($item) {
                 $item = is_object($item) ? get_object_vars($item) : $item;
+                if (isset($item['date_inscription']) && !isset($item['date_licence'])) {
+                    $item['date_licence'] = $item['date_inscription'];
+                }
                 if (isset($item['is_included']) && !isset($item['quota'])) {
                     $item['quota'] = $item['is_included'];
                 }

--- a/tests/phpunit/test-licence-list-table.php
+++ b/tests/phpunit/test-licence-list-table.php
@@ -95,5 +95,34 @@ class Test_Licence_List_Table extends WP_UnitTestCase {
 
         unset( $_REQUEST['s'] );
     }
+
+    /**
+     * Ensure set_external_data populates date_licence when missing
+     */
+    public function test_set_external_data_defaults_date_licence() {
+        if ( ! class_exists( 'UFSC_Licence_List_Table' ) ) {
+            $this->markTestSkipped( 'List table class not available' );
+        }
+
+        $table = new UFSC_Licence_List_Table();
+        $date  = '2024-01-01 00:00:00';
+
+        $data = [
+            (object) [
+                'id'               => 1,
+                'nom'              => 'Doe',
+                'prenom'           => 'John',
+                'email'            => 'john@example.com',
+                'statut'           => 'validee',
+                'date_inscription' => $date,
+            ],
+        ];
+
+        $table->set_external_data( $data, 1, 20 );
+        $table->prepare_items();
+
+        $this->assertArrayHasKey( 'date_licence', $table->items[0] );
+        $this->assertEquals( $date, $table->items[0]['date_licence'] );
+    }
 }
 


### PR DESCRIPTION
## Summary
- default `date_licence` to `date_inscription` when missing in `UFSC_Licence_List_Table::set_external_data`
- test that external data populates `date_licence`

## Testing
- `php -l includes/licences/class-ufsc-licence-list-table.php`
- `php -l tests/phpunit/test-licence-list-table.php`
- `phpunit tests/phpunit/test-licence-list-table.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af83e627e4832b87298052203a6092