### PR TITLE
Ensure licence search exposes registration date

### DIFF
--- a/includes/repository/class-licence-repository.php
+++ b/includes/repository/class-licence-repository.php
@@ -262,11 +262,21 @@ class UFSC_Licence_Repository
         $offset           = ((int) $args['page'] - 1) * (int) $args['per_page'];
         $params_with_limit = array_merge($params, [(int) $args['per_page'], (int) $offset]);
 
-        $list_sql   = "SELECT l.*, l.is_included AS quota, c.nom AS club FROM {$this->table} l LEFT JOIN {$clubs_table} c ON l.club_id = c.id WHERE {$where_clause} ORDER BY l.date_inscription DESC LIMIT %d OFFSET %d";
+        $list_sql   = "SELECT l.*, l.is_included AS quota, c.nom AS club, l.date_inscription AS date_licence FROM {$this->table} l LEFT JOIN {$clubs_table} c ON l.club_id = c.id WHERE {$where_clause} ORDER BY l.date_inscription DESC LIMIT %d OFFSET %d";
         $list_query = empty($params)
             ? $this->wpdb->prepare($list_sql, (int) $args['per_page'], (int) $offset)
             : $this->wpdb->prepare($list_sql, ...$params_with_limit);
         $items      = $this->wpdb->get_results($list_query, ARRAY_A);
+
+        $items = array_map(
+            static function (array $item): array {
+                if (!isset($item['date_licence']) && isset($item['date_inscription'])) {
+                    $item['date_licence'] = $item['date_inscription'];
+                }
+                return $item;
+            },
+            $items
+        );
 
         return [
             'items'    => $items,

--- a/tests/phpunit/test-licence-list-table.php
+++ b/tests/phpunit/test-licence-list-table.php
@@ -74,6 +74,7 @@ class Test_Licence_List_Table extends WP_UnitTestCase {
         $table->prepare_items();
 
         $this->assertGreaterThanOrEqual( 2, count( $table->items ), 'Expected unfiltered items' );
+        $this->assertArrayHasKey( 'date_licence', $table->items[0], 'Missing date_licence field' );
     }
 
     /**
@@ -92,8 +93,26 @@ class Test_Licence_List_Table extends WP_UnitTestCase {
 
         $this->assertCount( 1, $table->items );
         $this->assertEquals( 'Smith', $table->items[0]['nom'] );
+        $this->assertArrayHasKey( 'date_licence', $table->items[0], 'Missing date_licence field' );
 
         unset( $_REQUEST['s'] );
+    }
+
+    /**
+     * Ensure repository search returns date_licence key
+     */
+    public function test_repository_search_includes_date_licence() {
+        if ( ! class_exists( 'UFSC_Licence_Repository' ) ) {
+            require_once dirname( __DIR__, 2 ) . '/includes/repository/class-licence-repository.php';
+        }
+
+        $this->seed_data();
+
+        $repo   = new UFSC_Licence_Repository();
+        $result = $repo->search( [] );
+
+        $this->assertNotEmpty( $result['items'] );
+        $this->assertArrayHasKey( 'date_licence', $result['items'][0] );
     }
 }
 


### PR DESCRIPTION
## Summary
- Expose `date_licence` in `UFSC_Licence_Repository::search`
- Guarantee search results include the `date_licence` key
- Test list table and repository for `date_licence` presence

## Testing
- `phpunit` *(fails: command not found)*
- `php -l includes/repository/class-licence-repository.php`
- `php -l tests/phpunit/test-licence-list-table.php`


------
https://chatgpt.com/codex/tasks/task_e_68af83d1799c832b8776ed440cacf2a9