### PR TITLE
Use get_by_id for licence retrieval

### DIFF
--- a/includes/licences/admin-licence-edit.php
+++ b/includes/licences/admin-licence-edit.php
@@ -32,7 +32,7 @@ if (!isset($_GET['_wpnonce']) || !wp_verify_nonce(wp_unslash($_GET['_wpnonce']),
 }
 
 $repo = new UFSC_Licenses_Repository();
-$current_licence = $repo->get($licence_id);
+$current_licence = $repo->get_by_id($licence_id);
 $is_validated = $current_licence && $current_licence->statut === 'validee';
 
 if (!$current_licence) {
@@ -108,7 +108,7 @@ if (isset($_SERVER['REQUEST_METHOD']) && $_SERVER['REQUEST_METHOD'] === 'POST' &
         if ($success) {
             echo '<div class="notice notice-success"><p>✅ Licence modifiée avec succès.</p></div>';
             // Reload the licence data to show updated values
-            $current_licence = $repo->get($licence_id);
+            $current_licence = $repo->get_by_id($licence_id);
             $club = $wpdb->get_row($wpdb->prepare(
                 "SELECT * FROM {$wpdb->prefix}ufsc_clubs WHERE id = %d",
                 $current_licence->club_id

--- a/includes/licences/admin-licence-form.php
+++ b/includes/licences/admin-licence-form.php
@@ -18,7 +18,7 @@ require_once UFSC_PLUGIN_PATH . 'includes/licences/validation.php';
 
 $repo       = new UFSC_Licence_Repository();
 $licence_id = isset($_GET['licence_id']) ? absint( wp_unslash( $_GET['licence_id'] ) ) : 0;
-$licence    = $licence_id ? $repo->get($licence_id) : null;
+$licence    = $licence_id ? $repo->get_by_id($licence_id) : null;
 $errors     = [];
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && check_admin_referer('ufsc_license_admin_action', 'ufsc_license_admin_nonce')) {
@@ -87,7 +87,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && check_admin_referer('ufsc_license_a
             $licence_id = $repo->insert($data);
             echo '<div class="notice notice-success"><p>' . esc_html__('Licence créée.', 'plugin-ufsc-gestion-club-13072025') . '</p></div>';
         }
-        $licence = $repo->get($licence_id);
+        $licence = $repo->get_by_id($licence_id);
     } else {
         echo '<div class="notice notice-error"><p>' . implode('<br>', array_map('esc_html', $errors)) . '</p></div>';
     }

--- a/includes/licences/class-licence-manager.php
+++ b/includes/licences/class-licence-manager.php
@@ -186,7 +186,7 @@ class UFSC_Licence_Manager
             return false;
         }
 
-        $existing = (array) $this->licence_repository->get($id);
+        $existing = (array) $this->licence_repository->get_by_id($id);
         $errors   = ufsc_validate_licence_data(array_merge($existing, $data), $status === 'validee');
         if (!empty($errors)) {
             return false;


### PR DESCRIPTION
## Summary
- replace legacy repository `get` calls with `get_by_id`
- ensure licence retrieval handles invalid IDs gracefully

## Testing
- `php -l includes/licences/admin-licence-form.php`
- `php -l includes/licences/admin-licence-edit.php`
- `php -l includes/licences/class-licence-manager.php`


------
https://chatgpt.com/codex/tasks/task_e_68af9bc45b4c832b9d3f9ba8f254efa3