### PR TITLE
Remove redundant licence repository require in admin form

### DIFF
--- a/includes/licences/admin-licence-form.php
+++ b/includes/licences/admin-licence-form.php
@@ -12,8 +12,6 @@ if ( ! class_exists( 'UFSC_Licence_Repository' ) ) {
     require_once UFSC_PLUGIN_PATH . 'includes/repository/class-licence-repository.php';
 }
 
-require_once UFSC_PLUGIN_PATH . 'includes/repository/class-licence-repository.php';
-
 require_once UFSC_PLUGIN_PATH . 'includes/licences/validation.php';
 
 $repo       = new UFSC_Licence_Repository();


### PR DESCRIPTION
## Summary
- remove duplicated UFSC_Licence_Repository require in licence admin form

## Testing
- `php -l includes/licences/admin-licence-form.php`
- `phpunit tests/phpunit` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68af9bc343fc832b93f7b5f8b2a7b6b1