### PR TITLE
Ensure licence list table headers and pagination

### DIFF
--- a/includes/licences/class-ufsc-licence-list-table.php
+++ b/includes/licences/class-ufsc-licence-list-table.php
@@ -250,16 +250,23 @@ class UFSC_Licence_List_Table extends WP_List_Table {
 
 
     public function prepare_items() {
-        if ($this->external_data) {
-            $this->items = $this->external_data['items'];
-            $total_items = $this->external_data['total_items'];
-            $per_page    = $this->external_data['per_page'];
-            $total_pages = (int) ceil($total_items / $per_page);
-            $this->set_pagination_args([
-                'total_items' => $total_items,
-                'per_page'    => $per_page,
-                'total_pages' => $total_pages,
-            ]);
+        $columns  = $this->get_columns();
+        $hidden   = [];
+        $sortable = $this->get_sortable_columns();
+        $this->_column_headers = [ $columns, $hidden, $sortable ];
+
+        if ( $this->external_data ) {
+            $this->items      = $this->external_data['items'];
+            $total_items      = $this->external_data['total_items'];
+            $per_page         = max( 1, (int) $this->external_data['per_page'] );
+            $total_pages      = (int) ceil( $total_items / $per_page );
+            $this->set_pagination_args(
+                [
+                    'total_items' => $total_items,
+                    'per_page'    => $per_page,
+                    'total_pages' => $total_pages,
+                ]
+            );
             return;
         }
 


### PR DESCRIPTION
## Summary
- initialize column headers in `UFSC_Licence_List_Table::prepare_items`
- validate `per_page` and pagination when using external data

## Testing
- `phpunit` *(fails: command not found)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b00fd12654832bb165a21186811219