### PR TITLE
Fix duplicate cart addition Ajax and use nonce

### DIFF
--- a/assets/js/ufsc-front.js
+++ b/assets/js/ufsc-front.js
@@ -120,17 +120,8 @@
       var id = $b.data('licenceId') || $b.data('licence-id');
       if(!id) return;
 
-        var club = $b.data('clubId') || $b.data('club-id') || (UFSC && UFSC.club_id) || '';
-        lock($b, 'Ajout…');
-        $.post(ajaxUrl, {
-          action: 'ufsc_add_to_cart',
-          licence_id: id,
-          club_id: club,
-          _ajax_nonce: (UFSC && UFSC.frontNonce) || ''
-        }).done(function(res){
-
       var club = $b.data('clubId') || $b.data('club-id') || (UFSC && UFSC.club_id) || '';
-      var nonce = (UFSC && (UFSC.frontNonce || (UFSC.nonces && UFSC.nonces.add_to_cart))) || '';
+      var nonce = $b.data('nonce') || (UFSC.frontNonce || (UFSC.nonces && UFSC.nonces.add_to_cart) || '');
       lock($b, 'Ajout…');
       $.post(ajaxUrl, {
         action: 'ufsc_add_to_cart',


### PR DESCRIPTION
## Summary
- remove duplicate Ajax request in ufsc-front.js `ufsc-add-to-cart`
- add nonce retrieval for cart addition and ensure `.post().done().fail().always()` chain

## Testing
- `node --check assets/js/ufsc-front.js`
- `node <<'NODE' ... (simulation)`

------
https://chatgpt.com/codex/tasks/task_e_68b056fd8d30832b9d7c62c7580698ee