### PR TITLE
Fix save draft button class in licence form

### DIFF
--- a/includes/frontend/forms/licence-form-render.php
+++ b/includes/frontend/forms/licence-form-render.php
@@ -278,7 +278,7 @@ function ufsc_render_licence_form($args = array()){
       </fieldset>
 
       <div class="ufsc-form-actions">
-        <button type="button" id="ufsc-save-draft" class="ufsc-btn ufsc-btn-secondary">💾 Enregistrer brouillon</button>
+        <button type="button" id="ufsc-save-draft" class="ufsc-btn ufsc-btn-secondary ufsc-save-draft">💾 Enregistrer brouillon</button>
         <button type="submit" class="ufsc-btn"><?php echo esc_html($args['submit_button_text']); ?></button>
       </div>
     </form>


### PR DESCRIPTION
## Summary
- add `ufsc-save-draft` class to licence form draft button so generic JS selector works

## Testing
- `npm test` *(fails: Missing script "test")*
- `sudo apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b056fa7608832b9d14880d8f1965ab