### PR TITLE
Ensure frontend-pro script uses plugins_url and add asset tests

### DIFF
--- a/Plugin_UFSC_GESTION_CLUB_13072025.php
+++ b/Plugin_UFSC_GESTION_CLUB_13072025.php
@@ -929,7 +929,7 @@ function ufsc_enqueue_frontend_pro_assets()
 
     wp_enqueue_script(
         'ufsc-frontend-pro-script',
-        UFSC_PLUGIN_URL . 'assets/js/frontend-pro.js',
+        plugins_url('assets/js/frontend-pro.js', __FILE__),
         ['jquery', 'ufsc-frontend-script'],
         UFSC_PLUGIN_VERSION,
         true

--- a/assets/build/manifest.json
+++ b/assets/build/manifest.json
@@ -1,5 +1,6 @@
 {
   "ufsc-frontend.js": {"file": "ufsc-frontend-3eaedd91.js"},
   "ufsc-frontend.css": {"file": "ufsc-frontend-5fb05fd5.css"},
-  "ufsc-forms.css": {"file": "ufsc-forms-4e3dceb6.css"}
+  "ufsc-forms.css": {"file": "ufsc-forms-4e3dceb6.css"},
+  "frontend-pro.js": {"file": "../js/frontend-pro.js"}
 }

--- a/tests/phpunit/test-frontend-pro-asset.php
+++ b/tests/phpunit/test-frontend-pro-asset.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Ensure that the frontend-pro.js asset is present.
+ *
+ * @package UFSC_Gestion_Club
+ */
+
+// Exit if accessed directly.
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Test_UFSC_Frontend_Pro_Asset extends WP_UnitTestCase {
+    /**
+     * Test that the frontend-pro.js file exists.
+     */
+    public function test_frontend_pro_js_exists() {
+        $path = dirname(__DIR__, 2) . '/assets/js/frontend-pro.js';
+        $this->assertFileExists($path, 'The frontend-pro.js file is missing.');
+    }
+}

--- a/tests/wp-cli/check-frontend-pro.php
+++ b/tests/wp-cli/check-frontend-pro.php
@@ -1,0 +1,10 @@
+<?php
+// Simple WP-CLI check to ensure frontend-pro.js exists.
+$file = dirname(__DIR__, 2) . '/assets/js/frontend-pro.js';
+if (!file_exists($file)) {
+    fwrite(STDERR, "Missing asset: {$file}\n");
+    exit(1);
+}
+// Output confirmation for CI visibility.
+fwrite(STDOUT, "Found asset: {$file}\n");
+


### PR DESCRIPTION
## Summary
- use `plugins_url` to enqueue the frontend-pro script
- include frontend-pro.js in build manifest
- add PHPUnit and WP-CLI checks for frontend-pro.js

## Testing
- `php -l Plugin_UFSC_GESTION_CLUB_13072025.php`
- `python -m json.tool assets/build/manifest.json`
- `php tests/wp-cli/check-frontend-pro.php`
- `wp eval-file tests/wp-cli/check-frontend-pro.php` *(fails: command not found)*
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0665521b8832b8f000a737b33eab4