### PR TITLE
Refactor textdomain loading

### DIFF
--- a/includes/core/class-gestionclub-core.php
+++ b/includes/core/class-gestionclub-core.php
@@ -17,13 +17,6 @@ class UFSC_GestionClub_Core
      */
     public static function init()
     {
-        // 🌍 Chargement de la traduction
-        load_plugin_textdomain(
-            'ufsc-domain',
-            false,
-            plugin_basename(dirname(__DIR__, 2)) . '/languages'
-        );
-
         // 🧩 Inclusion des classes
         require_once UFSC_PLUGIN_PATH . 'includes/clubs/class-club-manager.php';
         require_once UFSC_PLUGIN_PATH . 'includes/clubs/admin-club-list-page.php';
@@ -143,3 +136,17 @@ class UFSC_GestionClub_Core
         return self::$club_manager;
     }
 }
+
+/**
+ * Load the plugin text domain for internationalization.
+ */
+function ufsc_core_load_textdomain()
+{
+    load_plugin_textdomain(
+        'ufsc-domain',
+        false,
+        plugin_basename(dirname(__DIR__, 2)) . '/languages'
+    );
+}
+
+add_action('init', 'ufsc_core_load_textdomain');


### PR DESCRIPTION
## Summary
- decouple translation loading from plugin initialization
- hook dedicated `ufsc_core_load_textdomain` to `init`

## Testing
- `phpunit -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0704f9bf4832bb7c05691a1a2225a