### PR TITLE
Use prepared statements for season expiration and migrations

### DIFF
--- a/Plugin_UFSC_GESTION_CLUB_13072025.php
+++ b/Plugin_UFSC_GESTION_CLUB_13072025.php
@@ -2389,7 +2389,12 @@ function ufsc_run_migrations() {
     // Ensure columns exist for licences
     $col = $wpdb->get_var($wpdb->prepare("SHOW COLUMNS FROM {$t_lic} LIKE %s", 'statut'));
     if (!$col) {
-        $wpdb->query("ALTER TABLE {$t_lic} ADD COLUMN statut VARCHAR(20) NOT NULL DEFAULT 'brouillon'");
+        $wpdb->query(
+            $wpdb->prepare(
+                "ALTER TABLE {$t_lic} ADD COLUMN statut VARCHAR(20) NOT NULL DEFAULT %s",
+                'brouillon'
+            )
+        );
     }
     $col = $wpdb->get_var($wpdb->prepare("SHOW COLUMNS FROM {$t_lic} LIKE %s", 'date_creation'));
     if (!$col) {
@@ -2397,18 +2402,42 @@ function ufsc_run_migrations() {
     }
     $col = $wpdb->get_var($wpdb->prepare("SHOW COLUMNS FROM {$t_lic} LIKE %s", 'club_id'));
     if (!$col) {
-        $wpdb->query("ALTER TABLE {$t_lic} ADD COLUMN club_id BIGINT UNSIGNED NOT NULL DEFAULT 0");
+        $wpdb->query(
+            $wpdb->prepare(
+                "ALTER TABLE {$t_lic} ADD COLUMN club_id BIGINT UNSIGNED NOT NULL DEFAULT %d",
+                0
+            )
+        );
     }
     $col = $wpdb->get_var($wpdb->prepare("SHOW COLUMNS FROM {$t_lic} LIKE %s", 'payment_status'));
     if (!$col) {
-        $wpdb->query("ALTER TABLE {$t_lic} ADD COLUMN payment_status VARCHAR(20) NOT NULL DEFAULT 'pending'");
+        $wpdb->query(
+            $wpdb->prepare(
+                "ALTER TABLE {$t_lic} ADD COLUMN payment_status VARCHAR(20) NOT NULL DEFAULT %s",
+                'pending'
+            )
+        );
     }
 
     // Ensure columns for clubs logo
     $col = $wpdb->get_var($wpdb->prepare("SHOW COLUMNS FROM {$t_club} LIKE %s", 'pack_credits_total'));
-    if (!$col) { $wpdb->query("ALTER TABLE {$t_club} ADD COLUMN pack_credits_total INT NOT NULL DEFAULT 0"); }
+    if (!$col) {
+        $wpdb->query(
+            $wpdb->prepare(
+                "ALTER TABLE {$t_club} ADD COLUMN pack_credits_total INT NOT NULL DEFAULT %d",
+                0
+            )
+        );
+    }
     $col = $wpdb->get_var($wpdb->prepare("SHOW COLUMNS FROM {$t_club} LIKE %s", 'pack_credits_used'));
-    if (!$col) { $wpdb->query("ALTER TABLE {$t_club} ADD COLUMN pack_credits_used INT NOT NULL DEFAULT 0"); }
+    if (!$col) {
+        $wpdb->query(
+            $wpdb->prepare(
+                "ALTER TABLE {$t_club} ADD COLUMN pack_credits_used INT NOT NULL DEFAULT %d",
+                0
+            )
+        );
+    }
     $col = $wpdb->get_var($wpdb->prepare("SHOW COLUMNS FROM {$t_club} LIKE %s", 'logo_attachment_id'));
     if (!$col) {
         $wpdb->query("ALTER TABLE {$t_club} ADD COLUMN logo_attachment_id BIGINT UNSIGNED NULL");

--- a/includes/core/season-expiration.php
+++ b/includes/core/season-expiration.php
@@ -1,9 +1,58 @@
 <?php
 if (!defined('ABSPATH')) exit;
+
 add_option('ufsc_current_season', date('Y').'-'.(date('Y')+1), '', 'no');
-add_option('ufsc_expire_month', 8); add_option('ufsc_expire_day', 31);
-add_action('init', function(){ if (!wp_next_scheduled('ufsc_daily_cron')) wp_schedule_event(time()+3600,'daily','ufsc_daily_cron'); });
-add_action('admin_init', function(){ global $wpdb; $t=$wpdb->prefix.'ufsc_licences'; if(!$wpdb->get_var($wpdb->prepare("SHOW COLUMNS FROM {$t} LIKE %s",'date_expiration'))){ $wpdb->query("ALTER TABLE {$t} ADD COLUMN date_expiration DATE NULL, ADD INDEX (date_expiration)"); } });
-function ufsc_compute_expiration_date($ts=null){ $y=(int)date('Y',$ts?:current_time('timestamp')); $m=(int)get_option('ufsc_expire_month',8); $d=(int)get_option('ufsc_expire_day',31); $exp=mktime(0,0,0,$m,$d,$y); if(($ts?:current_time('timestamp'))>$exp){$exp=mktime(0,0,0,$m,$d,$y+1);} return date('Y-m-d',$exp); }
-add_action('woocommerce_order_status_changed', function($order_id,$from,$to,$order){ if(!in_array($to,array('processing','completed'),true)) return; global $wpdb; $t=$wpdb->prefix.'ufsc_licences'; $wpdb->query("UPDATE {$t} SET date_expiration=IFNULL(date_expiration,'".esc_sql(ufsc_compute_expiration_date())."') WHERE order_id=".intval($order_id)); },20,4);
-add_action('ufsc_daily_cron', function(){ global $wpdb; $t=$wpdb->prefix.'ufsc_licences'; $today=date('Y-m-d',current_time('timestamp')); $wpdb->query("UPDATE {$t} SET statut='expiree' WHERE date_expiration IS NOT NULL AND date_expiration<'{$today}' AND statut IN ('validee','validée')"); });
+add_option('ufsc_expire_month', 8);
+add_option('ufsc_expire_day', 31);
+
+add_action('init', function(){
+    if (!wp_next_scheduled('ufsc_daily_cron')) {
+        wp_schedule_event(time()+3600, 'daily', 'ufsc_daily_cron');
+    }
+});
+
+add_action('admin_init', function(){
+    global $wpdb;
+    $t = $wpdb->prefix . 'ufsc_licences';
+    if (!$wpdb->get_var($wpdb->prepare("SHOW COLUMNS FROM {$t} LIKE %s", 'date_expiration'))){
+        $wpdb->query("ALTER TABLE {$t} ADD COLUMN date_expiration DATE NULL, ADD INDEX (date_expiration)");
+    }
+});
+
+function ufsc_compute_expiration_date($ts=null){
+    $y = (int)date('Y', $ts ?: current_time('timestamp'));
+    $m = (int)get_option('ufsc_expire_month', 8);
+    $d = (int)get_option('ufsc_expire_day', 31);
+    $exp = mktime(0,0,0,$m,$d,$y);
+    if (($ts ?: current_time('timestamp')) > $exp){
+        $exp = mktime(0,0,0,$m,$d,$y+1);
+    }
+    return date('Y-m-d', $exp);
+}
+
+add_action('woocommerce_order_status_changed', function($order_id, $from, $to, $order){
+    if (!in_array($to, array('processing','completed'), true)) return;
+    global $wpdb;
+    $t = $wpdb->prefix . 'ufsc_licences';
+    $date = sanitize_text_field(ufsc_compute_expiration_date());
+    $wpdb->query(
+        $wpdb->prepare(
+            "UPDATE {$t} SET date_expiration = IFNULL(date_expiration, %s) WHERE order_id = %d",
+            $date,
+            absint($order_id)
+        )
+    );
+}, 20, 4);
+
+add_action('ufsc_daily_cron', function(){
+    global $wpdb;
+    $t = $wpdb->prefix . 'ufsc_licences';
+    $today = sanitize_text_field(date('Y-m-d', current_time('timestamp')));
+    $wpdb->query(
+        $wpdb->prepare(
+            "UPDATE {$t} SET statut='expiree' WHERE date_expiration IS NOT NULL AND date_expiration < %s AND statut IN ('validee','validée')",
+            $today
+        )
+    );
+});
+


### PR DESCRIPTION
## Summary
- sanitize expiration updates using prepared statements
- refactor migration column additions to use prepared defaults

## Testing
- `php -l includes/core/season-expiration.php`
- `php -l Plugin_UFSC_GESTION_CLUB_13072025.php`
- `phpunit tests/phpunit/test-ajax-save-draft.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0704b1b8c832bb6043b050f54642b