### PR TITLE
Use bootstrap function for admin initialization

### DIFF
--- a/Plugin_UFSC_GESTION_CLUB_13072025.php
+++ b/Plugin_UFSC_GESTION_CLUB_13072025.php
@@ -193,20 +193,25 @@ if (file_exists(UFSC_PLUGIN_PATH . 'includes/shortcodes-front.php')) {
 }
 
 /**
-* Initialize the menu and document manager
-     */
-    // Licences direct shortcode & ajax (added)
-    if (file_exists(UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/licenses-direct.php')) {
-        require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/licenses-direct.php';
-    }
-    if (file_exists(UFSC_PLUGIN_PATH . 'includes/frontend/ajax/licenses-direct.php')) {
-        require_once UFSC_PLUGIN_PATH . 'includes/frontend/ajax/licenses-direct.php';
-    }
+ * Initialize admin components.
+ * This includes menu registration and document management.
+ */
+// Licences direct shortcode & ajax (added)
+if (file_exists(UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/licenses-direct.php')) {
+    require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/licenses-direct.php';
+}
+if (file_exists(UFSC_PLUGIN_PATH . 'includes/frontend/ajax/licenses-direct.php')) {
+    require_once UFSC_PLUGIN_PATH . 'includes/frontend/ajax/licenses-direct.php';
+}
 
-    if (is_admin()) {
-        new UFSC_Menu();
-        UFSC_Document_Manager::get_instance();
-    }
+/**
+ * Bootstrap admin functionality by instantiating required classes.
+ */
+function ufsc_admin_bootstrap() {
+    new UFSC_Menu();
+    UFSC_Document_Manager::get_instance();
+}
+add_action('admin_init', 'ufsc_admin_bootstrap');
 
     /**
      * Load text domain for translations


### PR DESCRIPTION
## Summary
- prevent direct class instantiation by introducing `ufsc_admin_bootstrap`
- hook new bootstrap to `admin_init` for menu and document manager setup

## Testing
- `php -l Plugin_UFSC_GESTION_CLUB_13072025.php`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0704ab044832b912cc4500963f329