### PR TITLE
Add admin boot DB check for ufsc_clubs table

### DIFF
--- a/Plugin_UFSC_GESTION_CLUB_13072025.php
+++ b/Plugin_UFSC_GESTION_CLUB_13072025.php
@@ -205,13 +205,30 @@ if (file_exists(UFSC_PLUGIN_PATH . 'includes/frontend/ajax/licenses-direct.php')
 }
 
 /**
- * Bootstrap admin functionality by instantiating required classes.
+ * Bootstrap admin functionality and verify database connection.
+ *
+ * Runs a lightweight check against the ufsc_clubs table and logs any
+ * database errors instead of stopping execution.
  */
-function ufsc_admin_bootstrap() {
+function ufsc_admin_boot() {
+    global $wpdb;
+
+    // Lightweight table check
+    $wpdb->get_var( "SELECT 1 FROM {$wpdb->prefix}ufsc_clubs LIMIT 1" );
+
+    if ( ! empty( $wpdb->last_error ) ) {
+        $error_message = $wpdb->last_error;
+        error_log( '[UFSC] ' . $error_message );
+
+        add_action( 'admin_notices', function () use ( $error_message ) {
+            echo '<div class="notice notice-error"><p>' . esc_html( '[UFSC] ' . $error_message ) . '</p></div>';
+        } );
+    }
+
     new UFSC_Menu();
     UFSC_Document_Manager::get_instance();
 }
-add_action('admin_init', 'ufsc_admin_bootstrap');
+add_action( 'admin_init', 'ufsc_admin_boot' );
 
     /**
      * Load text domain for translations


### PR DESCRIPTION
## Summary
- Replace admin bootstrap with `ufsc_admin_boot` that pings the `ufsc_clubs` table and logs any database errors with a `[UFSC]` prefix
- Show an admin notice instead of halting execution when the check fails

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a2bcedb8832bb71d3dcacf1b084f