### PR TITLE
Run migrations on plugin activation

### DIFF
--- a/Plugin_UFSC_GESTION_CLUB_13072025.php
+++ b/Plugin_UFSC_GESTION_CLUB_13072025.php
@@ -30,7 +30,20 @@ define('UFSC_PLUGIN_PATH', plugin_dir_path(__FILE__));
 require_once UFSC_PLUGIN_PATH . 'includes/helpers.php';
 
 require_once UFSC_PLUGIN_PATH . 'includes/install/migrations.php';
-add_action('plugins_loaded', 'ufsc_run_migrations');
+
+// === Activation tasks ===
+if (!function_exists('ufsc_activate_plugin')) {
+    function ufsc_activate_plugin() {
+        if (function_exists('ufsc_run_migrations')) {
+            ufsc_run_migrations();
+        }
+        if (function_exists('ufsc_ensure_frontend_pages')) {
+            ufsc_ensure_frontend_pages();
+        }
+    }
+}
+register_activation_hook(__FILE__, 'ufsc_activate_plugin');
+
 // === Capabilities on activation ===
 if (!function_exists('ufsc_add_caps_on_activate')) {
     function ufsc_add_caps_on_activate() {

--- a/includes/admin/ufsc-page-creator.php
+++ b/includes/admin/ufsc-page-creator.php
@@ -151,10 +151,6 @@ function ufsc_admin_init_page_check() {
 // Hook into admin_init for lazy page creation check
 add_action('admin_init', 'ufsc_admin_init_page_check');
 
-// Register activation hook - this will be called from the main plugin file
-if (defined('UFSC_PLUGIN_MAIN_FILE')) {
-    register_activation_hook(UFSC_PLUGIN_MAIN_FILE, 'ufsc_ensure_frontend_pages');
-}
 
 /**
  * Retrieve the URL of the automatically created "Connexion Club" page.

--- a/includes/install/migrations.php
+++ b/includes/install/migrations.php
@@ -4,6 +4,7 @@ if (!defined('ABSPATH')) exit;
 if (!function_exists('ufsc_run_migrations')) {
 function ufsc_run_migrations() {
     global $wpdb;
+    require_once ABSPATH . 'wp-admin/includes/upgrade.php';
     $charset = $wpdb->get_charset_collate();
     $dbv_opt = 'ufsc_db_schema_version';
     $current = get_option($dbv_opt, '');
@@ -67,24 +68,21 @@ function ufsc_run_migrations() {
 
     // Logs table
     $logs_table = $wpdb->prefix . 'ufsc_licence_logs';
-    $exists = $wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $logs_table)) === $logs_table;
-    if (!$exists) {
-        $sql = "CREATE TABLE {$logs_table} (
-            id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
-            licence_id bigint(20) unsigned NOT NULL,
-            old_status varchar(50) NULL,
-            new_status varchar(50) NOT NULL,
-            user_id bigint(20) unsigned NULL,
-            created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
-            request_ip varchar(64) NULL,
-            user_agent varchar(191) NULL,
-            PRIMARY KEY (id),
-            KEY licence_id (licence_id),
-            KEY new_status (new_status),
-            KEY created_at (created_at)
-        ) {$charset};";
-        $wpdb->query($sql);
-    }
+    $sql = "CREATE TABLE {$logs_table} (
+        id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+        licence_id bigint(20) unsigned NOT NULL,
+        old_status varchar(50) NULL,
+        new_status varchar(50) NOT NULL,
+        user_id bigint(20) unsigned NULL,
+        created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        request_ip varchar(64) NULL,
+        user_agent varchar(191) NULL,
+        PRIMARY KEY (id),
+        KEY licence_id (licence_id),
+        KEY new_status (new_status),
+        KEY created_at (created_at)
+    ) {$charset};";
+    dbDelta($sql);
 
     if ($current !== $target) {
         update_option($dbv_opt, $target, true);


### PR DESCRIPTION
## Summary
- move migrations to activation hook and ensure frontend pages on activation
- apply dbDelta for licence log table creation
- remove obsolete activation hook from page creator file

## Testing
- `php -l Plugin_UFSC_GESTION_CLUB_13072025.php`
- `php -l includes/install/migrations.php`
- `php -l includes/admin/ufsc-page-creator.php`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b0a2bbd8fc832bbc49fd9a15d261eb