### PR TITLE
Protect admin context from frontend includes

### DIFF
--- a/Plugin_UFSC_GESTION_CLUB_13072025.php
+++ b/Plugin_UFSC_GESTION_CLUB_13072025.php
@@ -123,86 +123,89 @@ if (is_admin()) {
 require_once UFSC_PLUGIN_PATH . 'includes/admin/ufsc-page-creator.php';
 
 // Frontend files
-$file = UFSC_PLUGIN_PATH . 'includes/frontend/frontend-club-dashboard.php';
-if (file_exists($file)) {
-    require_once $file;
-} else {
-    if (defined('WP_DEBUG') && WP_DEBUG) {
-        error_log('UFSC Gestion Club: missing file ' . $file);
+if ( ! is_admin() ) {
+    $file = UFSC_PLUGIN_PATH . 'includes/frontend/frontend-club-dashboard.php';
+    if (file_exists($file)) {
+        require_once $file;
+    } else {
+        if (defined('WP_DEBUG') && WP_DEBUG) {
+            error_log('UFSC Gestion Club: missing file ' . $file);
+        }
     }
-}
-require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/club-form-shortcode.php';
-require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/affiliation-form-shortcode.php';
-require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/licence-button-shortcode.php';
-require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/club-menu-shortcode.php';
-require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/login-register-shortcode.php';
-require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/recent-licences-shortcode.php';
+    require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/club-form-shortcode.php';
+    require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/affiliation-form-shortcode.php';
+    require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/licence-button-shortcode.php';
+    require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/club-menu-shortcode.php';
+    require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/login-register-shortcode.php';
+    require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/recent-licences-shortcode.php';
 
-// New modular club dashboard
-require_once UFSC_PLUGIN_PATH . 'includes/frontend/club/dashboard.php';
+    // New modular club dashboard
+    require_once UFSC_PLUGIN_PATH . 'includes/frontend/club/dashboard.php';
 
-// New shortcodes for UFSC club management
-require_once UFSC_PLUGIN_PATH . 'includes/shortcodes.php';
+    // New shortcodes for UFSC club management
+    require_once UFSC_PLUGIN_PATH . 'includes/shortcodes.php';
 
-// Frontend attestation shortcodes and AJAX handlers
-require_once UFSC_PLUGIN_PATH . 'includes/shortcodes-attestations.php';
-require_once UFSC_PLUGIN_PATH . 'includes/ajax-handlers.php';
+    // Frontend attestation shortcodes and AJAX handlers
+    require_once UFSC_PLUGIN_PATH . 'includes/shortcodes-attestations.php';
+    require_once UFSC_PLUGIN_PATH . 'includes/ajax-handlers.php';
 
-// AJAX handler for adding licences to cart
-require_once UFSC_PLUGIN_PATH . 'includes/licences/ajax-add-to-cart.php';
+    // AJAX handler for adding licences to cart
+    require_once UFSC_PLUGIN_PATH . 'includes/licences/ajax-add-to-cart.php';
 
-// WooCommerce Integration
-require_once UFSC_PLUGIN_PATH . 'includes/frontend/affiliation-woocommerce.php';
-require_once UFSC_PLUGIN_PATH . 'includes/frontend/woocommerce-licence-form.php';
+    // WooCommerce Integration
+    require_once UFSC_PLUGIN_PATH . 'includes/frontend/affiliation-woocommerce.php';
+    require_once UFSC_PLUGIN_PATH . 'includes/frontend/woocommerce-licence-form.php';
 
-// New WooCommerce integration for frontend refonte
-require_once UFSC_PLUGIN_PATH . 'includes/frontend/woocommerce-affiliation-form.php';
+    // New WooCommerce integration for frontend refonte
+    require_once UFSC_PLUGIN_PATH . 'includes/frontend/woocommerce-affiliation-form.php';
 
-// New helper files for frontend refonte
-require_once UFSC_PLUGIN_PATH . 'includes/helpers/helpers-licence-status.php';
-require_once UFSC_PLUGIN_PATH . 'includes/helpers/helpers-product-buttons.php';
+    // New helper files for frontend refonte
+    require_once UFSC_PLUGIN_PATH . 'includes/helpers/helpers-licence-status.php';
+    require_once UFSC_PLUGIN_PATH . 'includes/helpers/helpers-product-buttons.php';
 
-// New frontend shortcodes
-require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/new-frontend-shortcodes.php';
+    // New frontend shortcodes
+    require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/new-frontend-shortcodes.php';
 
-// Dashboard overview shortcode
-require_once UFSC_PLUGIN_PATH . 'includes/frontend/dashboard/overview.php';
+    // Dashboard overview shortcode
+    require_once UFSC_PLUGIN_PATH . 'includes/frontend/dashboard/overview.php';
 
-// New WooCommerce integration class (consolidated)
-if (file_exists(UFSC_PLUGIN_PATH . 'includes/class-ufsc-woocommerce-integration.php')) {
-    require_once UFSC_PLUGIN_PATH . 'includes/class-ufsc-woocommerce-integration.php';
-}
+    // New WooCommerce integration class (consolidated)
+    if (file_exists(UFSC_PLUGIN_PATH . 'includes/class-ufsc-woocommerce-integration.php')) {
+        require_once UFSC_PLUGIN_PATH . 'includes/class-ufsc-woocommerce-integration.php';
+    }
 
-// Load cart item role metadata handling
-if (file_exists(UFSC_PLUGIN_PATH . 'includes/woocommerce/cart-item-role-meta.php')) {
-    require_once UFSC_PLUGIN_PATH . 'includes/woocommerce/cart-item-role-meta.php';
-}
+    // Load cart item role metadata handling
+    if (file_exists(UFSC_PLUGIN_PATH . 'includes/woocommerce/cart-item-role-meta.php')) {
+        require_once UFSC_PLUGIN_PATH . 'includes/woocommerce/cart-item-role-meta.php';
+    }
 
-// New WooCommerce e-commerce features
-if (file_exists(UFSC_PLUGIN_PATH . 'includes/woocommerce/auto-pack-affiliation.php')) {
-    require_once UFSC_PLUGIN_PATH . 'includes/woocommerce/auto-pack-affiliation.php';
-}
+    // New WooCommerce e-commerce features
+    if (file_exists(UFSC_PLUGIN_PATH . 'includes/woocommerce/auto-pack-affiliation.php')) {
+        require_once UFSC_PLUGIN_PATH . 'includes/woocommerce/auto-pack-affiliation.php';
+    }
 
-if (file_exists(UFSC_PLUGIN_PATH . 'includes/woocommerce/auto-order-admin-licences.php')) {
-    require_once UFSC_PLUGIN_PATH . 'includes/woocommerce/auto-order-admin-licences.php';
-}
+    if (file_exists(UFSC_PLUGIN_PATH . 'includes/woocommerce/auto-order-admin-licences.php')) {
+        require_once UFSC_PLUGIN_PATH . 'includes/woocommerce/auto-order-admin-licences.php';
+    }
 
-// Frontend shortcodes
-if (file_exists(UFSC_PLUGIN_PATH . 'includes/shortcodes-front.php')) {
-    require_once UFSC_PLUGIN_PATH . 'includes/shortcodes-front.php';
+    // Frontend shortcodes
+    if (file_exists(UFSC_PLUGIN_PATH . 'includes/shortcodes-front.php')) {
+        require_once UFSC_PLUGIN_PATH . 'includes/shortcodes-front.php';
+    }
+
+    // Licences direct shortcode & ajax (added)
+    if (file_exists(UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/licenses-direct.php')) {
+        require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/licenses-direct.php';
+    }
+    if (file_exists(UFSC_PLUGIN_PATH . 'includes/frontend/ajax/licenses-direct.php')) {
+        require_once UFSC_PLUGIN_PATH . 'includes/frontend/ajax/licenses-direct.php';
+    }
 }
 
 /**
  * Initialize admin components.
  * This includes menu registration and document management.
  */
-// Licences direct shortcode & ajax (added)
-if (file_exists(UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/licenses-direct.php')) {
-    require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/licenses-direct.php';
-}
-if (file_exists(UFSC_PLUGIN_PATH . 'includes/frontend/ajax/licenses-direct.php')) {
-    require_once UFSC_PLUGIN_PATH . 'includes/frontend/ajax/licenses-direct.php';
-}
 
 /**
  * Bootstrap admin functionality by instantiating required classes.
@@ -2568,11 +2571,11 @@ add_action('woocommerce_order_status_changed', function($order_id, $from, $to, $
     }
 }, 20, 4);
 
-require_once UFSC_PLUGIN_PATH . 'includes/frontend/hooks/cart-router.php';
-
-require_once UFSC_PLUGIN_PATH . 'includes/frontend/ajax/licence-drafts.php';
-
-require_once UFSC_PLUGIN_PATH . 'includes/frontend/hooks/form-capture.php';
+if ( ! is_admin() ) {
+    require_once UFSC_PLUGIN_PATH . 'includes/frontend/hooks/cart-router.php';
+    require_once UFSC_PLUGIN_PATH . 'includes/frontend/ajax/licence-drafts.php';
+    require_once UFSC_PLUGIN_PATH . 'includes/frontend/hooks/form-capture.php';
+}
 require_once UFSC_PLUGIN_PATH . 'includes/diag/endpoint.php';
 
 


### PR DESCRIPTION
## Summary
- Guard all frontend and shortcode includes so they load only on the public side
- Ensure cart router and other frontend hooks load only when not in admin

## Testing
- `php -l Plugin_UFSC_GESTION_CLUB_13072025.php`
- `phpunit` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b0a2b75e3c832b9c1da43aca21415a