### PR TITLE
Use unified loader for frontend includes

### DIFF
--- a/Plugin_UFSC_GESTION_CLUB_13072025.php
+++ b/Plugin_UFSC_GESTION_CLUB_13072025.php
@@ -192,87 +192,6 @@ function ufsc_load_admin_files() {
 }
 add_action('admin_init', 'ufsc_load_admin_files', 0);
 
-
-// Frontend files
-if ( ! is_admin() ) {
-    $file = UFSC_PLUGIN_PATH . 'includes/frontend/frontend-club-dashboard.php';
-    if (file_exists($file)) {
-        require_once $file;
-    } else {
-        if (defined('WP_DEBUG') && WP_DEBUG) {
-            error_log('UFSC Gestion Club: missing file ' . $file);
-        }
-    }
-    require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/club-form-shortcode.php';
-    require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/affiliation-form-shortcode.php';
-    require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/licence-button-shortcode.php';
-    require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/club-menu-shortcode.php';
-    require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/login-register-shortcode.php';
-    require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/recent-licences-shortcode.php';
-
-    // New modular club dashboard
-    require_once UFSC_PLUGIN_PATH . 'includes/frontend/club/dashboard.php';
-
-    // New shortcodes for UFSC club management
-    require_once UFSC_PLUGIN_PATH . 'includes/shortcodes.php';
-
-    // Frontend attestation shortcodes and AJAX handlers
-    require_once UFSC_PLUGIN_PATH . 'includes/shortcodes-attestations.php';
-    require_once UFSC_PLUGIN_PATH . 'includes/ajax-handlers.php';
-
-    // AJAX handler for adding licences to cart
-    require_once UFSC_PLUGIN_PATH . 'includes/licences/ajax-add-to-cart.php';
-
-    // WooCommerce Integration
-    require_once UFSC_PLUGIN_PATH . 'includes/frontend/affiliation-woocommerce.php';
-    require_once UFSC_PLUGIN_PATH . 'includes/frontend/woocommerce-licence-form.php';
-
-    // New WooCommerce integration for frontend refonte
-    require_once UFSC_PLUGIN_PATH . 'includes/frontend/woocommerce-affiliation-form.php';
-
-    // New helper files for frontend refonte
-    require_once UFSC_PLUGIN_PATH . 'includes/helpers/helpers-licence-status.php';
-    require_once UFSC_PLUGIN_PATH . 'includes/helpers/helpers-product-buttons.php';
-
-    // New frontend shortcodes
-    require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/new-frontend-shortcodes.php';
-
-    // Dashboard overview shortcode
-    require_once UFSC_PLUGIN_PATH . 'includes/frontend/dashboard/overview.php';
-
-    // New WooCommerce integration class (consolidated)
-    if (file_exists(UFSC_PLUGIN_PATH . 'includes/class-ufsc-woocommerce-integration.php')) {
-        require_once UFSC_PLUGIN_PATH . 'includes/class-ufsc-woocommerce-integration.php';
-    }
-
-    // Load cart item role metadata handling
-    if (file_exists(UFSC_PLUGIN_PATH . 'includes/woocommerce/cart-item-role-meta.php')) {
-        require_once UFSC_PLUGIN_PATH . 'includes/woocommerce/cart-item-role-meta.php';
-    }
-
-    // New WooCommerce e-commerce features
-    if (file_exists(UFSC_PLUGIN_PATH . 'includes/woocommerce/auto-pack-affiliation.php')) {
-        require_once UFSC_PLUGIN_PATH . 'includes/woocommerce/auto-pack-affiliation.php';
-    }
-
-    if (file_exists(UFSC_PLUGIN_PATH . 'includes/woocommerce/auto-order-admin-licences.php')) {
-        require_once UFSC_PLUGIN_PATH . 'includes/woocommerce/auto-order-admin-licences.php';
-    }
-
-    // Frontend shortcodes
-    if (file_exists(UFSC_PLUGIN_PATH . 'includes/shortcodes-front.php')) {
-        require_once UFSC_PLUGIN_PATH . 'includes/shortcodes-front.php';
-    }
-
-    // Licences direct shortcode & ajax (added)
-    if (file_exists(UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/licenses-direct.php')) {
-        require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/licenses-direct.php';
-    }
-    if (file_exists(UFSC_PLUGIN_PATH . 'includes/frontend/ajax/licenses-direct.php')) {
-        require_once UFSC_PLUGIN_PATH . 'includes/frontend/ajax/licenses-direct.php';
-    }
-}
-=======
 /**
  * Load frontend specific files.
  */
@@ -354,8 +273,6 @@ register_activation_hook(__FILE__, 'ufsc_activate_migrations');
  * Runs a lightweight check against the ufsc_clubs table and logs any
  * database errors instead of stopping execution.
  */
-
-function ufsc_admin_bootstrap() {
 
 function ufsc_admin_boot() {
     global $wpdb;


### PR DESCRIPTION
## Summary
- remove direct frontend include block and leftover merge marker
- hook `ufsc_load_frontend_files` on init to handle all frontend requirements
- drop stray `ufsc_admin_bootstrap` stub causing syntax error

## Testing
- `php -l Plugin_UFSC_GESTION_CLUB_13072025.php`


------
https://chatgpt.com/codex/tasks/task_e_68b0ad3b47e0832b93fd6718dd5ed939