### PR TITLE
Clean up admin bootstrap and fix syntax

### DIFF
--- a/Plugin_UFSC_GESTION_CLUB_13072025.php
+++ b/Plugin_UFSC_GESTION_CLUB_13072025.php
@@ -272,7 +272,6 @@ if ( ! is_admin() ) {
         require_once UFSC_PLUGIN_PATH . 'includes/frontend/ajax/licenses-direct.php';
     }
 }
-=======
 /**
  * Load frontend specific files.
  */
@@ -354,8 +353,6 @@ register_activation_hook(__FILE__, 'ufsc_activate_migrations');
  * Runs a lightweight check against the ufsc_clubs table and logs any
  * database errors instead of stopping execution.
  */
-
-function ufsc_admin_bootstrap() {
 
 function ufsc_admin_boot() {
     global $wpdb;


### PR DESCRIPTION
## Summary
- remove leftover merge artifact
- ensure `ufsc_admin_boot` is the sole admin bootstrap function

## Testing
- `php -l Plugin_UFSC_GESTION_CLUB_13072025.php`


------
https://chatgpt.com/codex/tasks/task_e_68b0ad3c6100832b9f6710ff76193b2f