### PR TITLE
Load Document Manager lazily for club validation hook

### DIFF
--- a/Plugin_UFSC_GESTION_CLUB_13072025.php
+++ b/Plugin_UFSC_GESTION_CLUB_13072025.php
@@ -639,7 +639,16 @@ function ufsc_handle_delete_club() {
 // Club validation AJAX handler - connects to Document Manager's validate_club() method
 // This hook validates clubs by checking required documents and updating status to 'valide'
 // Handles permissions, nonce verification, document validation, and status updates
-add_action('wp_ajax_ufsc_validate_club', array(UFSC_Document_Manager::get_instance(), 'validate_club'));
+add_action('wp_ajax_ufsc_validate_club', function () {
+    if (!class_exists('UFSC_Document_Manager')) {
+        if (function_exists('ufsc_load_admin_files')) {
+            ufsc_load_admin_files();
+        } else {
+            require_once UFSC_PLUGIN_PATH . 'includes/admin/class-document-manager.php';
+        }
+    }
+    UFSC_Document_Manager::get_instance()->validate_club();
+});
 
 // Delete license AJAX handler
 add_action('wp_ajax_ufsc_delete_licence', 'ufsc_handle_delete_licence');


### PR DESCRIPTION
## Summary
- Use a closure for `wp_ajax_ufsc_validate_club` so `UFSC_Document_Manager::get_instance()` runs only on hook execution
- Ensure `UFSC_Document_Manager` class is loaded via `ufsc_load_admin_files` fallback before calling `validate_club`

## Testing
- `php -l Plugin_UFSC_GESTION_CLUB_13072025.php`


------
https://chatgpt.com/codex/tasks/task_e_68b0b4023aac832b930b7c95ffb7ed10