### PR TITLE
Load overrides before plugin hooks

### DIFF
--- a/Plugin_UFSC_GESTION_CLUB_13072025.php
+++ b/Plugin_UFSC_GESTION_CLUB_13072025.php
@@ -144,6 +144,17 @@ spl_autoload_register(function($class) {
     }
 });
 
+// Load overrides early to ensure they are available before other hooks.
+$override = UFSC_PLUGIN_PATH . 'includes/overrides/club-licenses-override.php';
+if (file_exists($override)) {
+    require_once $override;
+}
+
+$profix_loader = UFSC_PLUGIN_PATH . 'includes/overrides_profix/_loader.php';
+if (file_exists($profix_loader)) {
+    require_once $profix_loader;
+}
+
 /**
  * Load files shared between admin and frontend.
  */
@@ -342,14 +353,6 @@ function ufsc_load_frontend_files() {
     $assets = UFSC_PLUGIN_PATH . 'includes/class-ufsc-assets.php';
     if (file_exists($assets)) {
         require_once $assets;
-    }
-    $override = UFSC_PLUGIN_PATH . 'includes/overrides/club-licenses-override.php';
-    if (file_exists($override)) {
-        require_once $override;
-    }
-    $profix_loader = __DIR__ . '/includes/overrides_profix/_loader.php';
-    if (defined('ABSPATH') && file_exists($profix_loader)) {
-        require_once $profix_loader;
     }
 }
 add_action('init', 'ufsc_load_frontend_files', 0);


### PR DESCRIPTION
## Summary
- Load `club-licenses-override.php` and `_loader.php` at plugin start so overrides are available before other hooks
- Clean up `ufsc_load_frontend_files()` by removing moved override loading

## Testing
- `php -l Plugin_UFSC_GESTION_CLUB_13072025.php`
- `phpunit --version` *(command not found; attempted apt-get update but received 403)*
- `npm test` *(no test script defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c2b96c88832bb3574e8c0e633b66