### PR TITLE
Add club management shortcodes

### DIFF
--- a/Plugin_UFSC_GESTION_CLUB_13072025.php
+++ b/Plugin_UFSC_GESTION_CLUB_13072025.php
@@ -220,6 +220,9 @@ if ( ! is_admin() ) {
     require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/club-menu-shortcode.php';
     require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/login-register-shortcode.php';
     require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/recent-licences-shortcode.php';
+    require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/dashboard-shortcode.php';
+    require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/licences-shortcode.php';
+    require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/club-profile-shortcode.php';
 
     // New modular club dashboard
     require_once UFSC_PLUGIN_PATH . 'includes/frontend/club/dashboard.php';
@@ -302,6 +305,9 @@ function ufsc_load_frontend_files() {
     require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/club-menu-shortcode.php';
     require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/login-register-shortcode.php';
     require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/recent-licences-shortcode.php';
+    require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/dashboard-shortcode.php';
+    require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/licences-shortcode.php';
+    require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/club-profile-shortcode.php';
     require_once UFSC_PLUGIN_PATH . 'includes/frontend/club/dashboard.php';
     require_once UFSC_PLUGIN_PATH . 'includes/shortcodes.php';
     require_once UFSC_PLUGIN_PATH . 'includes/shortcodes-attestations.php';

--- a/includes/frontend/shortcodes/club-profile-shortcode.php
+++ b/includes/frontend/shortcodes/club-profile-shortcode.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * UFSC Club Profile Shortcode
+ *
+ * Combines club profile information and document management
+ * into a single [ufsc_club_profile] shortcode. Access restricted
+ * to authenticated users that manage the club.
+ *
+ * @package UFSC_Gestion_Club
+ * @since 1.3.0
+ */
+
+// Exit if accessed directly
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Render club profile and documents sections.
+ *
+ * @param array $atts Shortcode attributes (unused)
+ * @return string HTML output
+ */
+function ufsc_club_profile_shortcode($atts = array()) {
+    if (!is_user_logged_in()) {
+        return '<div class="ufsc-alert ufsc-alert-error">' .
+               esc_html__('Vous devez être connecté pour accéder à cette page.', 'plugin-ufsc-gestion-club-13072025') .
+               '</div>';
+    }
+
+    $club = function_exists('ufsc_get_user_club') ? ufsc_get_user_club() : null;
+    if (!$club) {
+        return '<div class="ufsc-alert ufsc-alert-error">' .
+               esc_html__('Aucun club associé.', 'plugin-ufsc-gestion-club-13072025') .
+               '</div>';
+    }
+
+    if (!ufsc_verify_club_access($club->id)) {
+        return '<div class="ufsc-alert ufsc-alert-error">' .
+               esc_html__('Accès refusé.', 'plugin-ufsc-gestion-club-13072025') .
+               '</div>';
+    }
+
+    if (!function_exists('ufsc_club_render_profile')) {
+        require_once UFSC_PLUGIN_PATH . 'includes/frontend/club/club-infos.php';
+    }
+    if (!function_exists('ufsc_club_render_documents')) {
+        require_once UFSC_PLUGIN_PATH . 'includes/frontend/club/documents.php';
+    }
+
+    $output = '<div class="ufsc-club-profile">';
+    $output .= ufsc_club_render_profile($club);
+    $output .= ufsc_club_render_documents($club);
+    $output .= '</div>';
+
+    return $output;
+}
+
+// Register shortcode
+add_shortcode('ufsc_club_profile', 'ufsc_club_profile_shortcode');
+

--- a/includes/frontend/shortcodes/dashboard-shortcode.php
+++ b/includes/frontend/shortcodes/dashboard-shortcode.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * UFSC Dashboard Shortcode
+ *
+ * Provides the [ufsc_dashboard] shortcode which renders the
+ * club dashboard interface. Access is restricted to authenticated
+ * users that own a club.
+ *
+ * @package UFSC_Gestion_Club
+ * @since 1.3.0
+ */
+
+// Exit if accessed directly
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Render the club dashboard for the current user.
+ *
+ * @param array $atts Shortcode attributes.
+ * @return string Dashboard HTML or error message.
+ */
+function ufsc_dashboard_shortcode($atts = array()) {
+    // Verify authentication
+    if (!is_user_logged_in()) {
+        return '<div class="ufsc-alert ufsc-alert-error">' .
+               esc_html__('Vous devez être connecté pour accéder à cette page.', 'plugin-ufsc-gestion-club-13072025') .
+               '</div>';
+    }
+
+    // Check club association
+    $club = function_exists('ufsc_get_user_club') ? ufsc_get_user_club() : null;
+    if (!$club || !ufsc_verify_club_access($club->id)) {
+        return '<div class="ufsc-alert ufsc-alert-error">' .
+               esc_html__('Accès refusé : aucun club associé.', 'plugin-ufsc-gestion-club-13072025') .
+               '</div>';
+    }
+
+    // Ensure dashboard class is loaded
+    if (!class_exists('UFSC_Club_Dashboard')) {
+        require_once UFSC_PLUGIN_PATH . 'includes/frontend/club/dashboard.php';
+    }
+
+    $dashboard = new UFSC_Club_Dashboard();
+    return $dashboard->render($atts);
+}
+
+// Register shortcode
+add_shortcode('ufsc_dashboard', 'ufsc_dashboard_shortcode');
+

--- a/includes/frontend/shortcodes/licences-shortcode.php
+++ b/includes/frontend/shortcodes/licences-shortcode.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * UFSC Licences Shortcode
+ *
+ * Displays the licence management table for the current user's club
+ * via the [ufsc_licences] shortcode. Users must be authenticated and
+ * associated with the club they attempt to view.
+ *
+ * @package UFSC_Gestion_Club
+ * @since 1.3.0
+ */
+
+// Exit if accessed directly
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Render licence management table
+ *
+ * @param array $atts Shortcode attributes (unused)
+ * @return string HTML output
+ */
+function ufsc_licences_shortcode($atts = array()) {
+    // Authentication check
+    if (!is_user_logged_in()) {
+        return '<div class="ufsc-alert ufsc-alert-error">' .
+               esc_html__('Vous devez être connecté pour accéder à cette page.', 'plugin-ufsc-gestion-club-13072025') .
+               '</div>';
+    }
+
+    // Retrieve club for current user
+    $club = function_exists('ufsc_get_user_club') ? ufsc_get_user_club() : null;
+    if (!$club) {
+        return '<div class="ufsc-alert ufsc-alert-error">' .
+               esc_html__('Aucun club associé.', 'plugin-ufsc-gestion-club-13072025') .
+               '</div>';
+    }
+
+    // Verify ownership
+    if (!ufsc_verify_club_access($club->id)) {
+        return '<div class="ufsc-alert ufsc-alert-error">' .
+               esc_html__('Accès refusé.', 'plugin-ufsc-gestion-club-13072025') .
+               '</div>';
+    }
+
+    // Load rendering functions
+    if (!function_exists('ufsc_club_render_licences')) {
+        require_once UFSC_PLUGIN_PATH . 'includes/frontend/club/licences.php';
+    }
+
+    return ufsc_club_render_licences($club);
+}
+
+// Register shortcode
+add_shortcode('ufsc_licences', 'ufsc_licences_shortcode');
+

--- a/includes/frontend/shortcodes/login-register-shortcode.php
+++ b/includes/frontend/shortcodes/login-register-shortcode.php
@@ -307,3 +307,4 @@ function ufsc_get_dashboard_url() {
 
 // Register the shortcode
 add_shortcode('ufsc_login_register', 'ufsc_login_register_shortcode');
+add_shortcode('ufsc_login_form', 'ufsc_login_register_shortcode');


### PR DESCRIPTION
## Summary
- add `[ufsc_login_form]` for login/registration
- create `[ufsc_dashboard]` shortcode for club dashboard access
- add `[ufsc_licences]` and `[ufsc_club_profile]` shortcodes with authentication checks

## Testing
- `php -l includes/frontend/shortcodes/dashboard-shortcode.php`
- `php -l includes/frontend/shortcodes/licences-shortcode.php`
- `php -l includes/frontend/shortcodes/club-profile-shortcode.php`
- `php -l includes/frontend/shortcodes/login-register-shortcode.php`


------
https://chatgpt.com/codex/tasks/task_e_68b7c8ff2a04832bb07070f8b2c228b5