### PR TITLE
feat: add document fields and status badges

### DIFF
--- a/includes/shortcodes-front.php
+++ b/includes/shortcodes-front.php
@@ -735,20 +735,20 @@ function ufsc_render_club_account_form($club, $atts) {
                     
                     foreach ($documents as $field => $label):
                         $doc_value = $club->{$field} ?? '';
-                        if (!empty($doc_value)):
-                            $doc_url = ufsc_resolve_document_url($doc_value);
-                            if ($doc_url):
+                        $status = !empty($doc_value) ? '✅ Transmis' : '⏳ En cours';
+                        $doc_url = !empty($doc_value) ? ufsc_resolve_document_url($doc_value) : '';
                     ?>
                     <div class="ufsc-document-item">
                         <span class="ufsc-document-name"><?php echo esc_html($label); ?></span>
-                        <a href="<?php echo esc_url($doc_url); ?>" class="ufsc-btn ufsc-btn-small ufsc-btn-outline" target="_blank">
-                            <?php esc_html_e('Télécharger', 'plugin-ufsc-gestion-club-13072025'); ?>
-                        </a>
+                        <span class="ufsc-document-status"><?php echo esc_html($status); ?></span>
+                        <?php if (!empty($doc_url)): ?>
+                            <a href="<?php echo esc_url($doc_url); ?>" class="ufsc-btn ufsc-btn-small ufsc-btn-outline" target="_blank">
+                                <?php esc_html_e('Télécharger', 'plugin-ufsc-gestion-club-13072025'); ?>
+                            </a>
+                        <?php endif; ?>
                     </div>
-                    <?php 
-                            endif;
-                        endif;
-                    endforeach; 
+                    <?php
+                    endforeach;
                     ?>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- add dedicated club document fields and centralize uploads through UFSC validator
- surface document transfer status with success and pending badges
- wire profile view to show each document's current status

## Testing
- `php -l includes/frontend/club/documents.php`
- `php -l includes/clubs/form-club.php`
- `php -l includes/shortcodes-front.php`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c8fe09b0832ba1b2b2b494227b32