### PR TITLE
Add login form shortcode with affiliation payment flow

### DIFF
--- a/Plugin_UFSC_GESTION_CLUB_13072025.php
+++ b/Plugin_UFSC_GESTION_CLUB_13072025.php
@@ -219,6 +219,7 @@ if ( ! is_admin() ) {
     require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/licence-button-shortcode.php';
     require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/club-menu-shortcode.php';
     require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/login-register-shortcode.php';
+    require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/login-form.php';
     require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/recent-licences-shortcode.php';
 
     // New modular club dashboard
@@ -355,6 +356,16 @@ function ufsc_load_frontend_files() {
     }
 }
 add_action('init', 'ufsc_load_frontend_files', 0);
+
+// Redirect new registrations to the club creation page
+add_filter('registration_redirect', 'ufsc_redirect_after_registration', 10, 2);
+function ufsc_redirect_after_registration($redirect_to, $user) {
+    $club_form = ufsc_get_safe_page_url('club_form');
+    if ($club_form['available']) {
+        return $club_form['url'];
+    }
+    return $redirect_to;
+}
 /**
  * Bootstrap admin functionality and verify database connection.
  *

--- a/includes/clubs/form-club.php
+++ b/includes/clubs/form-club.php
@@ -266,8 +266,8 @@ function ufsc_render_club_form($club_id = 0, $is_frontend = false, $is_affiliati
                 echo '<p>Votre club a été enregistré avec succès.</p>';
 
                 if ($is_frontend) {
-                    echo '<p><a href="' . esc_url(get_permalink(get_option('ufsc_affiliation_page_id'))) . '" class="ufsc-btn ufsc-btn-red">
-                        Procéder à l\'affiliation du club</a></p>';
+                    $pay_url = add_query_arg('ufsc_pay_affiliation', $club_id, home_url('/'));
+                    echo '<p><a href="' . esc_url($pay_url) . '" class="ufsc-btn ufsc-btn-red">Payer l\'affiliation</a></p>';
                 }
 
                 echo '</div>';

--- a/includes/frontend/hooks/cart-router.php
+++ b/includes/frontend/hooks/cart-router.php
@@ -44,3 +44,28 @@ add_action('template_redirect', function(){
         wp_safe_redirect( wc_get_checkout_url() ); exit;
     }
 });
+
+/**
+ * Route front pour ajouter l'affiliation au panier et rediriger vers le paiement.
+ * Utilisation : /?ufsc_pay_affiliation=ID_CLUB
+ */
+add_action('template_redirect', function(){
+    if (empty($_GET['ufsc_pay_affiliation'])) return;
+    if (!is_user_logged_in()) { wp_safe_redirect( wp_login_url( wc_get_checkout_url() ) ); exit; }
+
+    $club_id = absint( wp_unslash( $_GET['ufsc_pay_affiliation'] ) );
+    $club_manager = UFSC_Club_Manager::get_instance();
+    $club = $club_manager->get_club($club_id);
+    if (!$club) { wp_safe_redirect( home_url('/') ); exit; }
+
+    if (class_exists('WC')){
+        if (!WC()->cart) wc_load_cart();
+        $data = array(
+            'ufsc_club_id' => $club_id,
+            'ufsc_club_nom' => $club->nom,
+            'ufsc_product_type' => 'affiliation',
+        );
+        WC()->cart->add_to_cart( ufsc_get_affiliation_product_id_safe(), 1, 0, array(), $data );
+        wp_safe_redirect( wc_get_checkout_url() ); exit;
+    }
+});

--- a/includes/frontend/shortcodes/login-form.php
+++ b/includes/frontend/shortcodes/login-form.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * UFSC Login Form Shortcode
+ *
+ * Displays a simple login form with a registration CTA. If the user is
+ * authenticated, it shows either the club creation form or a link to the
+ * dashboard depending on whether the user already has an associated club.
+ *
+ * Usage: [ufsc_login_form]
+ *
+ * @package UFSC_Gestion_Club
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+function ufsc_login_form_shortcode($atts = []) {
+    // Logged in users
+    if (is_user_logged_in()) {
+        $user_id = get_current_user_id();
+        $club    = function_exists('ufsc_get_user_club') ? ufsc_get_user_club($user_id) : null;
+
+        // If user has no club, show club creation form directly
+        if (!$club) {
+            if (!function_exists('ufsc_render_club_form')) {
+                require_once UFSC_PLUGIN_PATH . 'includes/clubs/form-club.php';
+            }
+            ob_start();
+            echo '<div class="ufsc-container"><div class="ufsc-grid"><div class="ufsc-card">';
+            ufsc_render_club_form(0, true, false);
+            echo '</div></div></div>';
+            return ob_get_clean();
+        }
+
+        // If club exists, show dashboard access
+        $dashboard = ufsc_get_safe_page_url('dashboard');
+        if ($dashboard['available']) {
+            return '<div class="ufsc-container"><div class="ufsc-grid"><div class="ufsc-card">'
+                . '<a href="' . esc_url($dashboard['url']) . '" class="ufsc-btn ufsc-btn-primary">'
+                . esc_html__('Accéder au tableau de bord', 'plugin-ufsc-gestion-club-13072025')
+                . '</a></div></div></div>';
+        }
+
+        return '<div class="ufsc-container"><div class="ufsc-grid"><div class="ufsc-card">'
+            . esc_html__('Tableau de bord indisponible', 'plugin-ufsc-gestion-club-13072025')
+            . '</div></div></div>';
+    }
+
+    // Not logged in: show login form with registration CTA
+    if (!function_exists('ufsc_render_login_form')) {
+        require_once UFSC_PLUGIN_PATH . 'includes/frontend/shortcodes/login-register-shortcode.php';
+    }
+
+    $output = '<div class="ufsc-container"><div class="ufsc-grid"><div class="ufsc-card">';
+    $output .= ufsc_render_login_form('');
+    $output .= '<p class="ufsc-login-cta"><a class="ufsc-btn ufsc-btn-secondary" href="'
+        . esc_url(wp_registration_url()) . '">'
+        . esc_html__('Créer un compte', 'plugin-ufsc-gestion-club-13072025') . '</a></p>';
+    $output .= '</div></div></div>';
+
+    return $output;
+}
+add_shortcode('ufsc_login_form', 'ufsc_login_form_shortcode');

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -630,7 +630,7 @@ function ufsc_check_frontend_access($context = 'general')
     
     // Get user's club
     $club = ufsc_get_user_club($user_id);
-    
+
     if (!$club) {
         // Allow managers to bypass club check
         if (function_exists('ufsc_safe_current_user_can') && ufsc_safe_current_user_can('ufsc_manage', $user_id)) {
@@ -664,7 +664,21 @@ function ufsc_check_frontend_access($context = 'general')
             'club' => null
         ];
     }
-    
+
+    // If club exists but affiliation hasn't been paid, block dashboard access
+    if ($context === 'dashboard' && isset($club->statut) && $club->statut === 'En cours de création') {
+        $pay_url = add_query_arg('ufsc_pay_affiliation', $club->id, home_url('/'));
+        $pay_button = '<a href="' . esc_url($pay_url) . '" class="ufsc-btn ufsc-btn-primary">'
+            . esc_html__('Payer l\'affiliation', 'plugin-ufsc-gestion-club-13072025') . '</a>';
+        return [
+            'allowed' => false,
+            'error_message' => '<div class="ufsc-alert ufsc-alert-warning"><p>'
+                . esc_html__('Votre club n\'est pas encore affilié.', 'plugin-ufsc-gestion-club-13072025')
+                . '</p><p>' . $pay_button . '</p></div>',
+            'club' => $club
+        ];
+    }
+
     return [
         'allowed' => true,
         'error_message' => '',


### PR DESCRIPTION
## Summary
- add `[ufsc_login_form]` shortcode with club-aware rendering
- redirect new registrations to club creation
- enable affiliation payment button and access control

## Testing
- `php -l includes/frontend/shortcodes/login-form.php`
- `php -l Plugin_UFSC_GESTION_CLUB_13072025.php`
- `php -l includes/frontend/hooks/cart-router.php`
- `php -l includes/clubs/form-club.php`
- `php -l includes/helpers.php`
- `phpunit --version` *(fails: command not found)*
- `php tests/phpunit/test-ajax-save-draft.php` *(fails: Class "WP_UnitTestCase" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c8fdb92c832bade93d7889e05885