### PR TITLE
Handle licence actions and secure edits

### DIFF
--- a/Plugin_UFSC_GESTION_CLUB_13072025.php
+++ b/Plugin_UFSC_GESTION_CLUB_13072025.php
@@ -339,6 +339,8 @@ function ufsc_load_frontend_files() {
         require_once UFSC_PLUGIN_PATH . 'includes/frontend/ajax/licence-drafts.php';
     }
     require_once UFSC_PLUGIN_PATH . 'includes/frontend/hooks/form-capture.php';
+    require_once UFSC_PLUGIN_PATH . 'includes/frontend/handlers/submit-licence.php';
+    require_once UFSC_PLUGIN_PATH . 'includes/frontend/handlers/delete-licence.php';
     require_once UFSC_PLUGIN_PATH . 'includes/diag/endpoint.php';
 
     $assets = UFSC_PLUGIN_PATH . 'includes/class-ufsc-assets.php';

--- a/includes/frontend/club/licences.php
+++ b/includes/frontend/club/licences.php
@@ -28,28 +28,23 @@ function ufsc_club_render_licences($club){
  */
 function ufscsn_render_actions($id, $statut, $is_included, $edit_url, $cart_url, $order_id = 0, $payment_status = '') {
     ob_start();
-    $nonce = wp_create_nonce('ufsc_add_to_cart_' . $id);
+    $view_url = add_query_arg('view_licence', (int) $id, get_permalink());
     ?>
     <div class="ufsc-actions">
-      <a class="button button-secondary" title="<?php esc_attr_e('Modifier','plugin-ufsc-gestion-club-13072025'); ?>" href="<?php echo esc_url($edit_url); ?>"><?php _e('Modifier','plugin-ufsc-gestion-club-13072025'); ?></a>
-      <?php if ($statut === 'brouillon'): ?>
-        <button type="button" class="button ufsc-delete-draft" data-licence-id="<?php echo (int)$id; ?>"><?php _e('Supprimer','plugin-ufsc-gestion-club-13072025'); ?></button>
-        <?php if (!ufsc_is_payment_paid($payment_status)): ?>
-        <button type="button" class="button button-primary ufsc-add-to-cart"
-          data-licence-id="<?php echo (int)$id; ?>"
-          data-nonce="<?php echo esc_attr($nonce); ?>"><?php _e('Envoyer au panier','plugin-ufsc-gestion-club-13072025'); ?></button>
-        <?php endif; ?>
-        <button type="button" class="button ufsc-include-quota" data-licence-id="<?php echo (int)$id; ?>"><?php echo $is_included ? esc_html__('Retirer du quota','plugin-ufsc-gestion-club-13072025') : esc_html__('Inclure au quota','plugin-ufsc-gestion-club-13072025'); ?></button>
-      <?php elseif ($statut === 'in_cart'): ?>
-        <a class="button" href="<?php echo esc_url($cart_url); ?>"><?php _e('Voir panier','plugin-ufsc-gestion-club-13072025'); ?></a>
-      <?php elseif (in_array($statut, ['en_attente','refusee'], true)): ?>
-        <?php if (empty($order_id)): ?>
-          <a class="button button-primary" href="<?php echo esc_url( add_query_arg('ufsc_pay_licence', (int)$id, home_url('/')) ); ?>"><?php _e('Payer','plugin-ufsc-gestion-club-13072025'); ?></a>
-        <?php else: ?>
-          <a class="button" href="<?php echo esc_url( home_url('/mon-compte/orders/') ); ?>"><?php _e('Voir commande','plugin-ufsc-gestion-club-13072025'); ?></a>
-        <?php endif; ?>
-      <?php else: ?>
-        <a class="button" href="<?php echo esc_url( add_query_arg('view_licence', (int)$id, get_permalink()) ); ?>"><?php _e('Voir','plugin-ufsc-gestion-club-13072025'); ?></a>
+      <a class="button" href="<?php echo esc_url($view_url); ?>"><?php _e('Consulter','plugin-ufsc-gestion-club-13072025'); ?></a>
+      <?php if (in_array($statut, ['brouillon','pending_payment','refusee'], true)): ?>
+        <a class="button button-secondary" href="<?php echo esc_url($edit_url); ?>"><?php _e('Modifier','plugin-ufsc-gestion-club-13072025'); ?></a>
+      <?php elseif ($payment_status === 'paid' || $statut === 'validee'): ?>
+        <?php echo ufsc_get_license_status_badge($statut, $payment_status); ?>
+      <?php endif; ?>
+
+      <?php if (in_array($statut, ['brouillon','pending_payment'], true)): ?>
+        <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" class="ufsc-inline-form">
+          <?php wp_nonce_field('ufsc_delete_licence_' . (int) $id); ?>
+          <input type="hidden" name="action" value="ufsc_delete_licence" />
+          <input type="hidden" name="licence_id" value="<?php echo (int) $id; ?>" />
+          <button type="submit" class="button ufsc-btn-delete"><?php _e('Supprimer','plugin-ufsc-gestion-club-13072025'); ?></button>
+        </form>
       <?php endif; ?>
     </div>
     <?php

--- a/includes/frontend/handlers/delete-licence.php
+++ b/includes/frontend/handlers/delete-licence.php
@@ -1,0 +1,34 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+function ufsc_delete_licence() {
+    if (!is_user_logged_in() || !current_user_can('ufsc_manage_own')) {
+        wp_die(__('Accès refusé.', 'plugin-ufsc-gestion-club-13072025'));
+    }
+
+    $licence_id = isset($_POST['licence_id']) ? absint($_POST['licence_id']) : 0;
+    if (!$licence_id) {
+        wp_die(__('Licence invalide.', 'plugin-ufsc-gestion-club-13072025'));
+    }
+
+    check_admin_referer('ufsc_delete_licence_' . $licence_id);
+
+    global $wpdb;
+    $table    = $wpdb->prefix . 'ufsc_licences';
+    $club_rel = $wpdb->prefix . 'ufsc_user_clubs';
+
+    $club_id       = (int) $wpdb->get_var($wpdb->prepare("SELECT club_id FROM {$club_rel} WHERE user_id=%d LIMIT 1", get_current_user_id()));
+    $licence_club  = (int) $wpdb->get_var($wpdb->prepare("SELECT club_id FROM {$table} WHERE id=%d", $licence_id));
+
+    if (!$club_id || $club_id !== $licence_club) {
+        wp_die(__('Licence introuvable ou accès refusé.', 'plugin-ufsc-gestion-club-13072025'));
+    }
+
+    $wpdb->delete($table, ['id' => $licence_id], ['%d']);
+
+    $redirect = remove_query_arg(['licence_id', '_wpnonce'], wp_get_referer() ?: home_url('/'));
+    wp_safe_redirect($redirect);
+    exit;
+}
+add_action('admin_post_nopriv_ufsc_delete_licence', 'ufsc_delete_licence');
+add_action('admin_post_ufsc_delete_licence', 'ufsc_delete_licence');


### PR DESCRIPTION
## Summary
- Simplify licence row actions: always show **Consulter**, show **Modifier** only when editable, and expose a nonce-protected POST **Supprimer** button
- Block server-side edits of paid or validated licences and redirect to read-only view with notice
- Add `ufsc_delete_licence` admin-post handler with capability, nonce, and ownership checks

## Testing
- `php -l Plugin_UFSC_GESTION_CLUB_13072025.php`
- `php -l includes/frontend/club/licences.php`
- `php -l includes/frontend/handlers/submit-licence.php`
- `php -l includes/frontend/handlers/delete-licence.php`


------
https://chatgpt.com/codex/tasks/task_e_68b7c8fa4e94832b86ffd819ae8680c9