### PR TITLE
Automate affiliation checkout with AJAX CTA

### DIFF
--- a/Plugin_UFSC_GESTION_CLUB_13072025.php
+++ b/Plugin_UFSC_GESTION_CLUB_13072025.php
@@ -1050,6 +1050,12 @@ function ufsc_handle_save_club_ajax() {
                 'timestamp' => current_time('mysql')
             ];
 
+            // Trigger affiliation payment flow for new clubs
+            if (!$is_edit && function_exists('ufsc_add_affiliation_to_cart')) {
+                ufsc_add_affiliation_to_cart($club_id, false);
+                $response_data['redirect_url'] = wc_get_checkout_url();
+            }
+
             // Send notification email for new clubs
             if (!$is_edit && !is_admin()) {
                 ufsc_send_club_notification_email($fresh_club_data);

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -357,13 +357,33 @@ jQuery(document).ready(function ($) {
                     $(this).remove();
                 });
             });
-            
+
             // Handle retry buttons
             $(document).on('click', '.ufsc-retry-btn', function() {
                 const $form = $(this).closest('.ufsc-form');
                 if ($form.length) {
                     UFSCDataSync.submitClubForm($form);
                 }
+            });
+
+            // Handle "Payer mon affiliation" CTA
+            $(document).on('click', '.ufsc-pay-affiliation', function(e) {
+                e.preventDefault();
+                const clubId = $(this).data('club-id') || 0;
+
+                $.post(UFSCDataSync.config.ajaxUrl, {
+                    action: 'ufsc_add_affiliation_to_cart',
+                    club_id: clubId,
+                    nonce: UFSCDataSync.config.nonce
+                }).done(function(response) {
+                    if (response.success && response.data.redirect) {
+                        window.location.href = response.data.redirect;
+                    } else if (response.data && response.data.message) {
+                        ufscToast(response.data.message, 'error');
+                    }
+                }).fail(function() {
+                    ufscToast('Erreur lors de l\'ajout au panier', 'error');
+                });
             });
         },
 

--- a/includes/helpers/helpers-product-buttons.php
+++ b/includes/helpers/helpers-product-buttons.php
@@ -32,7 +32,8 @@ function ufsc_render_product_button($product_id, $label, $classes = '', $context
         'show_tooltip' => true,
         'check_club_status' => true,
         'redirect_url' => '',
-        'button_type' => 'link' // 'link', 'button', 'form'
+        'button_type' => 'link', // 'link', 'button', 'form'
+        'extra_attrs' => ''
     ];
     $options = wp_parse_args($options, $defaults);
 
@@ -119,19 +120,21 @@ function ufsc_render_product_button($product_id, $label, $classes = '', $context
         $button_attrs .= ' title="' . esc_attr($tooltip) . '"';
     }
 
+    $extra_attrs = !empty($options['extra_attrs']) ? ' ' . $options['extra_attrs'] : '';
+
     switch ($options['button_type']) {
         case 'button':
-            return '<button type="button" class="' . esc_attr($button_classes) . '"' . $button_attrs . ' onclick="window.location.href=\'' . esc_url($final_url) . '\'">' . 
+            return '<button type="button" class="' . esc_attr($button_classes) . '"' . $button_attrs . $extra_attrs . ' onclick="window.location.href=\'' . esc_url($final_url) . '\'">' .
                    esc_html($label) . '</button>';
 
         case 'form':
             return '<form method="get" action="' . esc_url($final_url) . '" style="display:inline;">
-                    <button type="submit" class="' . esc_attr($button_classes) . '"' . $button_attrs . '>' . esc_html($label) . '</button>
+                    <button type="submit" class="' . esc_attr($button_classes) . '"' . $button_attrs . $extra_attrs . '>' . esc_html($label) . '</button>
                     </form>';
 
         case 'link':
         default:
-            return '<a href="' . esc_url($final_url) . '" class="' . esc_attr($button_classes) . '"' . $button_attrs . '>' . 
+            return '<a href="' . esc_url($final_url) . '" class="' . esc_attr($button_classes) . '"' . $button_attrs . $extra_attrs . '>' .
                    esc_html($label) . '</a>';
     }
 }
@@ -206,10 +209,17 @@ function ufsc_generate_affiliation_button($args = [])
     // Determine if this is a renewal
     $user_id = get_current_user_id();
     $existing_club = $user_id ? ufsc_get_user_club($user_id) : null;
-    
+
     if ($existing_club && !ufsc_is_club_active($existing_club)) {
         $args['label'] = 'Renouveler l\'affiliation';
     }
+
+    $extra_attrs = '';
+    if ($existing_club) {
+        $extra_attrs = 'data-club-id="' . intval($existing_club->id) . '"';
+    }
+
+    $args['classes'] .= ' ufsc-pay-affiliation';
 
     return ufsc_render_product_button(
         ufsc_get_affiliation_product_id_safe(),
@@ -217,7 +227,8 @@ function ufsc_generate_affiliation_button($args = [])
         $args['classes'],
         $args['context'],
         [
-            'check_club_status' => false // Affiliation doesn't require existing active club
+            'check_club_status' => false, // Affiliation doesn't require existing active club
+            'extra_attrs' => $extra_attrs
         ]
     );
 }


### PR DESCRIPTION
## Summary
- Extend `ufsc_add_affiliation_to_cart` to add the affiliation product, redirect to checkout, and expose an AJAX endpoint
- Trigger affiliation cart insertion after club creation and wire up CTA click handling
- Allow affiliation buttons to carry club ID metadata for JS

## Testing
- `php -l includes/frontend/affiliation-woocommerce.php`
- `php -l includes/helpers/helpers-product-buttons.php`
- `php -l Plugin_UFSC_GESTION_CLUB_13072025.php`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b7c8f3f198832bb261e5b8d55fa9fc