### PR TITLE
Route club and licence forms through admin-post handlers

### DIFF
--- a/Plugin_UFSC_GESTION_CLUB_13072025.php
+++ b/Plugin_UFSC_GESTION_CLUB_13072025.php
@@ -42,6 +42,8 @@ if (!defined('UFSC_MANAGE_LICENSES_CAP')) {
 require_once UFSC_PLUGIN_PATH . 'includes/helpers.php';
 
 require_once UFSC_PLUGIN_PATH . 'includes/install/migrations.php';
+require_once UFSC_PLUGIN_PATH . 'includes/controllers/save-club.php';
+require_once UFSC_PLUGIN_PATH . 'includes/controllers/save-licence.php';
 
 
 // === Activation tasks ===

--- a/includes/clubs/form-club.php
+++ b/includes/clubs/form-club.php
@@ -49,7 +49,7 @@ function ufsc_render_club_form($club_id = 0, $is_frontend = false, $is_affiliati
         $form_submitted = true;
 
         // Vérification du nonce
-        if (!isset($_POST['ufsc_club_nonce']) || !wp_verify_nonce(wp_unslash($_POST['ufsc_club_nonce']), 'ufsc_save_club')) {
+        if (!isset($_POST['ufsc_save_club_nonce']) || !wp_verify_nonce(wp_unslash($_POST['ufsc_save_club_nonce']), 'ufsc_save_club')) {
             $errors[] = 'Erreur de sécurité. Veuillez recharger la page.';
         } else {
             // Récupération des données de base
@@ -327,8 +327,9 @@ function ufsc_render_club_form($club_id = 0, $is_frontend = false, $is_affiliati
         <h2 class="ufsc-section-title"><?php echo esc_html($form_title); ?></h2>
         <?php endif; ?>
         
-        <form method="post" enctype="multipart/form-data" class="ufsc-form" data-ajax-enabled="true" data-is-affiliation="<?php echo $is_affiliation ? 'true' : 'false'; ?>">
-            <?php wp_nonce_field('ufsc_save_club', 'ufsc_club_nonce'); ?>
+        <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" enctype="multipart/form-data" class="ufsc-form" data-ajax-enabled="true" data-is-affiliation="<?php echo $is_affiliation ? 'true' : 'false'; ?>">
+            <?php wp_nonce_field('ufsc_save_club', 'ufsc_save_club_nonce'); ?>
+            <input type="hidden" name="action" value="ufsc_save_club">
             <input type="hidden" name="ufsc_save_club_submit" value="1">
             
             <?php if ($is_edit): ?>

--- a/includes/controllers/save-licence.php
+++ b/includes/controllers/save-licence.php
@@ -1,0 +1,83 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+function ufsc_handle_save_licence() {
+    $action = isset($_POST['action']) ? sanitize_text_field(wp_unslash($_POST['action'])) : '';
+    $nonce_field = $action === 'ufsc_update_licence' ? 'ufsc_update_licence_nonce' : 'ufsc_add_licence_nonce';
+
+    if (!isset($_POST[$nonce_field]) || !wp_verify_nonce(wp_unslash($_POST[$nonce_field]), $action)) {
+        wp_die(__('Security check failed.', 'plugin-ufsc-gestion-club-13072025'));
+    }
+
+    if (!current_user_can('ufsc_manage') && !current_user_can('ufsc_manage_own')) {
+        wp_die(__('Permissions insuffisantes.', 'plugin-ufsc-gestion-club-13072025'));
+    }
+
+    $club = function_exists('ufsc_get_user_club') ? ufsc_get_user_club(get_current_user_id()) : null;
+    if (!$club) {
+        wp_die(__('Club introuvable.', 'plugin-ufsc-gestion-club-13072025'));
+    }
+    $club_id = is_object($club) ? intval($club->id) : intval($club['id']);
+
+    global $wpdb;
+    $table = $wpdb->prefix . 'ufsc_licences';
+
+    $licence_id = isset($_POST['licence_id']) ? intval(wp_unslash($_POST['licence_id'])) : 0;
+    if ($action === 'ufsc_update_licence') {
+        if (!$licence_id) {
+            wp_die(__('Licence invalide.', 'plugin-ufsc-gestion-club-13072025'));
+        }
+        $existing_club = (int) $wpdb->get_var($wpdb->prepare("SELECT club_id FROM {$table} WHERE id=%d", $licence_id));
+        if (!current_user_can('ufsc_manage') && $existing_club !== $club_id) {
+            wp_die(__('Accès refusé.', 'plugin-ufsc-gestion-club-13072025'));
+        }
+    }
+
+    $allowed_fields = [
+        'nom', 'prenom', 'sexe', 'date_naissance', 'email', 'adresse', 'suite_adresse',
+        'code_postal', 'ville', 'tel_fixe', 'tel_mobile', 'profession', 'identifiant_laposte',
+        'region', 'numero_licence_delegataire', 'note', 'fonction'
+    ];
+
+    $data = [];
+    foreach ($allowed_fields as $field) {
+        $value = isset($_POST[$field]) ? wp_unslash($_POST[$field]) : '';
+        if ($field === 'email') {
+            $data[$field] = sanitize_email($value);
+        } else {
+            $data[$field] = sanitize_text_field($value);
+        }
+    }
+
+    $checkboxes = [
+        'reduction_benevole', 'reduction_postier', 'fonction_publique', 'competition',
+        'licence_delegataire', 'diffusion_image', 'infos_fsasptt', 'infos_asptt',
+        'infos_cr', 'infos_partenaires', 'honorabilite', 'assurance_dommage_corporel',
+        'assurance_assistance'
+    ];
+
+    foreach ($checkboxes as $key) {
+        $data[$key] = isset($_POST[$key]) ? 1 : 0;
+    }
+
+    if ($action === 'ufsc_update_licence') {
+        $wpdb->update($table, $data, ['id' => $licence_id]);
+    } else {
+        $data['club_id'] = $club_id;
+        $data['date_inscription'] = current_time('mysql');
+        $data['statut'] = 'brouillon';
+        $wpdb->insert($table, $data);
+    }
+
+    $redirect = wp_get_referer() ? wp_get_referer() : home_url('/');
+    $redirect = add_query_arg('licence_saved', '1', $redirect);
+    wp_safe_redirect($redirect);
+    exit;
+}
+
+add_action('admin_post_ufsc_add_licence', 'ufsc_handle_save_licence');
+add_action('admin_post_nopriv_ufsc_add_licence', 'ufsc_handle_save_licence');
+add_action('admin_post_ufsc_update_licence', 'ufsc_handle_save_licence');
+add_action('admin_post_nopriv_ufsc_update_licence', 'ufsc_handle_save_licence');

--- a/includes/frontend/parts/licence-form.php
+++ b/includes/frontend/parts/licence-form.php
@@ -15,8 +15,8 @@ $club = $access_check['club'];
 
 // Handle form submission - different actions based on button clicked
 if (isset($_SERVER['REQUEST_METHOD']) && $_SERVER['REQUEST_METHOD'] === 'POST'
-    && isset($_POST['ufsc_add_licence_front_nonce'])
-    && wp_verify_nonce(wp_unslash($_POST['ufsc_add_licence_front_nonce']), 'ufsc_add_licence_front')
+    && isset($_POST['ufsc_add_licence_nonce'])
+    && wp_verify_nonce(wp_unslash($_POST['ufsc_add_licence_nonce']), 'ufsc_add_licence')
 ) {
     // Determine action based on submitted button
     $action = 'cart';
@@ -229,9 +229,10 @@ $quota_percentage = $quota_total > 0 ? min(100, ($licences_count / $quota_total)
         <?php endif; ?>
         
         <div class="ufsc-card-body">
-            <form method="post" class="ufsc-form ufsc-licence-form">
+            <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="ufsc-form ufsc-licence-form">
                 <div id="ufsc-form-status" class="ufsc-form-status" role="status" aria-live="polite" aria-atomic="true"></div>
-                <?php wp_nonce_field('ufsc_add_licence_front', 'ufsc_add_licence_front_nonce'); ?>
+                <?php wp_nonce_field('ufsc_add_licence', 'ufsc_add_licence_nonce'); ?>
+                <input type="hidden" name="action" value="ufsc_add_licence">
                 
                 <div class="ufsc-form-section">
                     <h4 class="ufsc-form-section-title">Informations personnelles</h4>
@@ -513,7 +514,7 @@ $quota_percentage = $quota_total > 0 ? min(100, ($licences_count / $quota_total)
                 
                 <div class="ufsc-form-actions">
                     <div class="ufsc-form-actions-primary">
-                        <button type="submit" name="ufsc_add_licence_front" class="ufsc-btn ufsc-btn-red ufsc-btn-large">
+                        <button type="submit" name="ufsc_add_licence" class="ufsc-btn ufsc-btn-red ufsc-btn-large">
                             <i class="dashicons dashicons-cart"></i>
                             Ajouter au panier
                         </button>


### PR DESCRIPTION
## Summary
- Post club and licence forms to `admin-post.php` with action and nonce fields
- Add robust save handlers validating permissions and ownership before saving
- Load new controllers on plugin init

## Testing
- `php -l includes/clubs/form-club.php`
- `php -l includes/frontend/parts/licence-form.php`
- `php -l includes/controllers/save-club.php`
- `php -l includes/controllers/save-licence.php`
- `php -l Plugin_UFSC_GESTION_CLUB_13072025.php`


------
https://chatgpt.com/codex/tasks/task_e_68b7c8f0eaa0832bac72a15c1f73b1ae