### PR TITLE
Allow deleting pending licences

### DIFF
--- a/assets/js/ufsc-licenses-direct.js
+++ b/assets/js/ufsc-licenses-direct.js
@@ -92,6 +92,12 @@
               <button class="ufscx-btn ufscx-btn-primary" data-a="pay" data-id="${r.id}" aria-label="Envoyer la licence ${r.id} au paiement">Envoyer au paiement</button>
             `;
           }
+          if(status==='en_attente'){
+            return `
+              <button class="ufscx-btn ufscx-btn-soft" data-a="edit" data-id="${r.id}" aria-label="Modifier la licence ${r.id}">Modifier</button>
+              <button class="ufscx-btn ufscx-btn-soft" data-a="delete" data-id="${r.id}" aria-label="Supprimer la licence ${r.id}">Supprimer</button>
+            `;
+          }
           if(status==='in_cart'){
             return `<button class="ufscx-btn ufscx-btn-soft" data-a="viewcart" data-id="${r.id}" aria-label="Voir le panier de la licence ${r.id}">Voir panier</button>`;
           }

--- a/includes/frontend/ajax/licenses-direct.php
+++ b/includes/frontend/ajax/licenses-direct.php
@@ -42,8 +42,8 @@ function ufscx_delete_draft(){
     if (!$club_id || (int)$row->club_id !== (int)$club_id){
         wp_send_json_error(['message'=>esc_html__('Non autorisé', 'ufsc-domain')],403);
     }
-    if (!in_array(strtolower($row->statut), ['brouillon','draft'], true)){
-        wp_send_json_error(['message'=>esc_html__('Suppression autorisée uniquement pour les brouillons.', 'ufsc-domain')]);
+    if (!in_array(strtolower($row->statut), ['brouillon','draft','en_attente'], true)){
+        wp_send_json_error(['message'=>esc_html__('Suppression autorisée uniquement pour les brouillons ou les licences en attente.', 'ufsc-domain')]);
     }
     $wpdb->delete($t, ['id'=>$id]);
     wp_send_json_success(['deleted'=>true]);

--- a/languages/plugin-ufsc-gestion-club-13072025-fr_FR.po
+++ b/languages/plugin-ufsc-gestion-club-13072025-fr_FR.po
@@ -83,3 +83,7 @@ msgstr "Mise à jour de la base de données requise."
 
 msgid "Settings saved successfully."
 msgstr "Paramètres sauvegardés avec succès."
+
+#: includes/frontend/ajax/licenses-direct.php
+msgid "Suppression autorisée uniquement pour les brouillons ou les licences en attente."
+msgstr "Suppression autorisée uniquement pour les brouillons ou les licences en attente."

--- a/languages/plugin-ufsc-gestion-club-13072025.pot
+++ b/languages/plugin-ufsc-gestion-club-13072025.pot
@@ -83,3 +83,7 @@ msgstr ""
 
 msgid "Settings saved successfully."
 msgstr ""
+
+# Licence deletion messages
+msgid "Suppression autorisée uniquement pour les brouillons ou les licences en attente."
+msgstr ""


### PR DESCRIPTION
## Summary
- Allow editing and deleting of `en_attente` licences in the direct licence list
- Permit deletion of pending licences server-side with clearer error messaging
- Localize deletion error text in translation templates

## Testing
- ⚠️ `npm test` (missing script)
- ✅ `npm run build`
- ✅ `php -l includes/frontend/ajax/licenses-direct.php`


------
https://chatgpt.com/codex/tasks/task_e_68b7d5415410832b905732744e416aa1