### PR TITLE
Handle en_attente draft status in license actions

### DIFF
--- a/assets/js/ufsc-licenses-direct.js
+++ b/assets/js/ufsc-licenses-direct.js
@@ -85,7 +85,7 @@
           if(isFinal) {
             return `<button class="ufscx-btn ufscx-btn-soft" disabled title="Licence finalisée - modification impossible" aria-label="Modifier (désactivé)">Modifier</button>`;
           }
-          if(status==='brouillon'){
+          if(status==='brouillon' || status==='en_attente'){
             return `
               <button class="ufscx-btn ufscx-btn-soft" data-a="edit" data-id="${r.id}" aria-label="Modifier la licence ${r.id}">Modifier</button>
               <button class="ufscx-btn ufscx-btn-soft" data-a="delete" data-id="${r.id}" aria-label="Supprimer la licence ${r.id}">Supprimer</button>

--- a/includes/frontend/ajax/licenses-direct.php
+++ b/includes/frontend/ajax/licenses-direct.php
@@ -42,8 +42,8 @@ function ufscx_delete_draft(){
     if (!$club_id || (int)$row->club_id !== (int)$club_id){
         wp_send_json_error(['message'=>esc_html__('Non autorisé', 'ufsc-domain')],403);
     }
-    if (!in_array(strtolower($row->statut), ['brouillon','draft'], true)){
-        wp_send_json_error(['message'=>esc_html__('Suppression autorisée uniquement pour les brouillons.', 'ufsc-domain')]);
+    if (!in_array(strtolower($row->statut), ['brouillon','draft','en_attente'], true)){
+        wp_send_json_error(['message'=>esc_html__('Suppression autorisée uniquement pour les brouillons ou en attente.', 'ufsc-domain')]);
     }
     $wpdb->delete($t, ['id'=>$id]);
     wp_send_json_success(['deleted'=>true]);

--- a/includes/frontend/shortcodes/licenses-direct.php
+++ b/includes/frontend/shortcodes/licenses-direct.php
@@ -148,7 +148,8 @@ function ufscx_licences_direct_shortcode($atts){
           <option value="">Statut : Tous</option>
           <option value="validee">Validée</option>
           <option value="brouillon">Brouillon</option>
-          <option value="pending_payment">En attente</option>
+          <option value="en_attente">En attente</option>
+          <option value="pending_payment">En attente de paiement</option>
         </select>
         <select id="ufscx-cat">
           <option value="">Catégorie : Tous</option>


### PR DESCRIPTION
## Summary
- Treat `en_attente` like `brouillon` in licence actions, enabling modify, delete and payment buttons
- Allow server-side draft deletion when status is `en_attente`
- Add `en_attente` to status filter and differentiate pending payment

## Testing
- `node --check assets/js/ufsc-licenses-direct.js`
- `php -l includes/frontend/ajax/licenses-direct.php`
- `php -l includes/frontend/shortcodes/licenses-direct.php`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7d52927e0832bb6d1d87e05174c94